### PR TITLE
Add an optional Caddy overlay for HTTPS

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -1,3 +1,22 @@
+# KorbKlar — Beispielkonfiguration. Kopieren nach .env.
+#
+# Der erste Block gilt immer. Die weiteren nur, wenn du die passende
+# Compose-Datei dazunimmst:
+#
+#   docker compose up -d                                   nur KorbKlar
+#   docker compose -f compose.yml -f compose.proxy.yml …    + HTTPS
+#
+# Siehe docs/deployment.de.md.
+
+# Welche Compose-Dateien dazugehören. Einmal hier eingetragen, genügt wieder
+# ein blankes "docker compose up -d" — auch für pull, logs, down.
+# Nur KorbKlar: Zeile weglassen.
+# Getrennt wird mit ":" unter Linux und macOS, mit ";" unter Windows.
+#COMPOSE_FILE=compose.yml:compose.proxy.yml
+
+
+# ── KorbKlar (compose.yml) ───────────────────────────────────────────────────
+
 # Host-Port des Docker-Dienstes. Intern bleibt der Container auf Port 8000.
 SUPERMARKT_PORT=8000
 
@@ -46,3 +65,26 @@ SUPERMARKT_REWE_STORE_CACHE_TTL_SECONDS=86400
 SUPERMARKT_IMAGE_CACHE_TTL_SECONDS=604800
 SUPERMARKT_IMAGE_CACHE_MAX_BYTES=536870912
 SUPERMARKT_IMAGE_MAX_FILE_BYTES=4194304
+
+
+# ── Reverse Proxy (compose.proxy.yml) ───────────────────────────────────────
+
+# Caddy holt und erneuert die Let's-Encrypt-Zertifikate selbst. Beide Werte
+# sind Pflicht, sobald compose.proxy.yml dabei ist.
+KORBKLAR_DOMAIN=
+KORBKLAR_ACME_EMAIL=
+# Schnittstelle, auf der KorbKlars eigener Port 8000 mit dem Proxy davor noch
+# veröffentlicht wird. 127.0.0.1 reicht für curl auf dem Host; eine
+# VPN-Adresse hält den Klartext-Weg für dieses Netz offen. Ohne
+# compose.proxy.yml wird der Port unverändert auf allen Schnittstellen
+# veröffentlicht und dieser Wert nicht gelesen.
+KORBKLAR_BIND_ADDRESS=127.0.0.1
+# Passwortschutz der Oberfläche über Caddy. Nur gelesen, wenn der
+# basic_auth-Block in deploy/caddy/sites/korbklar.caddy eingeschaltet ist.
+# Hash erzeugen: docker compose exec caddy caddy hash-password
+KORBKLAR_BASIC_AUTH_HASH=
+# Auf ./deploy/caddy/Caddyfile.kitchenowl setzen, um eine KitchenOwl im selben
+# Compose-Projekt auf einer zweiten Domain mitzubedienen. Dann ist
+# KORBKLAR_KITCHENOWL_DOMAIN Pflicht.
+KORBKLAR_CADDYFILE=./deploy/caddy/Caddyfile
+KORBKLAR_KITCHENOWL_DOMAIN=

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -34,6 +34,19 @@ jobs:
           set -Eeuo pipefail
           docker compose config >/dev/null
           SUPERMARKT_PORT=7333 docker compose config | grep -q 'published: "7333"'
+
+          # The proxy overlay must refuse to start without its domain, and with
+          # one it must take KorbKlar's port off the public interfaces.
+          if docker compose -f compose.yml -f compose.proxy.yml config >/dev/null 2>&1; then
+            echo "compose.proxy.yml must require KORBKLAR_DOMAIN" >&2
+            exit 1
+          fi
+          KORBKLAR_DOMAIN=korbklar.example.org KORBKLAR_ACME_EMAIL=ops@example.org \
+            docker compose -f compose.yml -f compose.proxy.yml config | grep -q 'host_ip: 127.0.0.1'
+          KORBKLAR_DOMAIN=korbklar.example.org KORBKLAR_ACME_EMAIL=ops@example.org \
+            KORBKLAR_CADDYFILE=./deploy/caddy/Caddyfile.kitchenowl \
+            docker compose -f compose.yml -f compose.proxy.yml config >/dev/null
+
           docker compose up -d --build
           trap 'docker compose down -v' EXIT
 

--- a/README.de.md
+++ b/README.de.md
@@ -88,6 +88,29 @@ Die Oberfläche ist dann unter `http://SERVER-IP:8080` erreichbar. Dauerhaft kan
 
 Die Laufzeitdaten liegen im Docker-Volume `korbklar-data` und bleiben bei normalen Container-Neustarts erhalten.
 
+## HTTPS mit Caddy
+
+Eine optionale zweite Compose-Datei stellt Caddy vor KorbKlar und lässt es die
+Let's-Encrypt-Zertifikate selbst holen und erneuern. Sie wird zur Basisdatei
+dazugenommen, nicht an ihrer Stelle gewählt:
+
+```bash
+KORBKLAR_DOMAIN=korbklar.deine-domain.example
+KORBKLAR_ACME_EMAIL=du@deine-domain.example
+docker compose -f compose.yml -f compose.proxy.yml up -d
+```
+
+Ohne sie startet der Stack unverändert; der Proxy-Container wird nie angelegt
+und seine beiden Pflichtwerte werden nie gelesen. Mit ihr wird KorbKlars
+eigener Port auf `127.0.0.1` umgebunden, damit niemand an der Verschlüsselung
+vorbeikommt, und `KORBKLAR_BIND_ADDRESS` kann einen Klartext-Weg fürs VPN
+offenhalten. Die Browser-Oberfläche hat keine eigene Anmeldung; eine
+öffentliche Domain will deshalb entweder ein VPN davor oder den
+`basic_auth`-Block in `deploy/caddy/sites/korbklar.caddy`.
+
+Kombinationen der Compose-Dateien, `COMPOSE_FILE`, eine zweite Domain und das
+Aktualisieren stehen in [docs/deployment.de.md](docs/deployment.de.md).
+
 ## Was bei einer Suche passiert
 
 ```text

--- a/README.en.md
+++ b/README.en.md
@@ -74,6 +74,28 @@ SUPERMARKT_PORT=8080 docker compose up -d --no-build
 
 The interface is then available at `http://SERVER-IP:8080`. The value may also be stored in an optional `.env` file.
 
+## HTTPS with Caddy
+
+An optional second compose file puts Caddy in front of KorbKlar and lets it
+obtain and renew Let's Encrypt certificates on its own. It is added to the base
+file rather than chosen instead of it:
+
+```bash
+KORBKLAR_DOMAIN=korbklar.your-domain.example
+KORBKLAR_ACME_EMAIL=you@your-domain.example
+docker compose -f compose.yml -f compose.proxy.yml up -d
+```
+
+Without it the stack starts unchanged; the proxy container is never created
+and its two required values are never read. With it, KorbKlar's own port is
+rebound to `127.0.0.1` so the encryption cannot be walked around, and
+`KORBKLAR_BIND_ADDRESS` can keep a plain path open for a VPN. The browser
+interface has no login of its own, so a public domain wants either a VPN in
+front or the `basic_auth` block in `deploy/caddy/sites/korbklar.caddy`.
+
+Compose file combinations, `COMPOSE_FILE`, a second domain and updating are in
+[docs/deployment.en.md](docs/deployment.en.md).
+
 ## What happens during a search
 
 ```text

--- a/compose.proxy.yml
+++ b/compose.proxy.yml
@@ -1,0 +1,62 @@
+# Optional: Caddy as a TLS terminator in front of KorbKlar.
+#
+#   docker compose -f compose.yml -f compose.proxy.yml up -d
+#
+# Caddy obtains and renews Let's Encrypt certificates on its own; there is no
+# certbot container and no cron job. Requires KORBKLAR_DOMAIN and
+# KORBKLAR_ACME_EMAIL in .env, and port 80 and 443 reachable from the internet
+# so the ACME challenge can complete.
+#
+# This overlay is added to compose.yml, never used on its own. It needs Docker
+# Compose v2.24 or newer for the !override tag below. See docs/deployment.md.
+
+services:
+  korbklar:
+    # With the proxy in front, KorbKlar's own port must not stay published on
+    # every interface, or the encryption can simply be walked around. !override
+    # replaces the mapping from compose.yml instead of adding a second one.
+    # 127.0.0.1 keeps it reachable for curl on the host; a VPN address
+    # (KORBKLAR_BIND_ADDRESS=10.8.0.1) keeps the plain http path open for that
+    # network alone. The container port stays 8000 either way.
+    ports: !override
+      - "${KORBKLAR_BIND_ADDRESS:-127.0.0.1}:${SUPERMARKT_PORT:-8000}:8000"
+
+  caddy:
+    image: caddy:2-alpine
+    container_name: korbklar-caddy
+    restart: unless-stopped
+    init: true
+    security_opt:
+      - no-new-privileges:true
+    depends_on:
+      korbklar:
+        condition: service_healthy
+    environment:
+      KORBKLAR_DOMAIN: "${KORBKLAR_DOMAIN:?Der Reverse Proxy braucht KORBKLAR_DOMAIN in .env}"
+      KORBKLAR_ACME_EMAIL: "${KORBKLAR_ACME_EMAIL:?Let's Encrypt braucht KORBKLAR_ACME_EMAIL in .env}"
+      # Only read by Caddyfile.kitchenowl.
+      KORBKLAR_KITCHENOWL_DOMAIN: ${KORBKLAR_KITCHENOWL_DOMAIN:-}
+      # Only read when the basic_auth block in sites/korbklar.caddy is enabled.
+      KORBKLAR_BASIC_AUTH_HASH: ${KORBKLAR_BASIC_AUTH_HASH:-}
+    ports:
+      - "80:80"
+      - "443:443"
+      - "443:443/udp"
+    volumes:
+      # KORBKLAR_CADDYFILE selects the entry point; the default knows KorbKlar
+      # only, Caddyfile.kitchenowl adds a second domain for KitchenOwl.
+      - ${KORBKLAR_CADDYFILE:-./deploy/caddy/Caddyfile}:/etc/caddy/Caddyfile:ro
+      # Both entry points import from here, so neither repeats the other.
+      - ./deploy/caddy/sites:/etc/caddy/sites:ro
+      - caddy-data:/data
+      - caddy-config:/config
+    healthcheck:
+      test: ["CMD", "caddy", "version"]
+      interval: 30s
+      timeout: 5s
+      retries: 3
+      start_period: 10s
+
+volumes:
+  caddy-data:
+  caddy-config:

--- a/deploy/caddy/Caddyfile
+++ b/deploy/caddy/Caddyfile
@@ -1,0 +1,8 @@
+# KorbKlar behind TLS. Used by compose.proxy.yml unless KORBKLAR_CADDYFILE
+# names a different entry point.
+
+{
+	email {$KORBKLAR_ACME_EMAIL}
+}
+
+import /etc/caddy/sites/korbklar.caddy

--- a/deploy/caddy/Caddyfile.kitchenowl
+++ b/deploy/caddy/Caddyfile.kitchenowl
@@ -1,0 +1,12 @@
+# KorbKlar and a KitchenOwl in the same compose project, each on its own
+# domain. Select with KORBKLAR_CADDYFILE=./deploy/caddy/Caddyfile.kitchenowl
+# and set KORBKLAR_KITCHENOWL_DOMAIN. The KitchenOwl web container has to be
+# reachable as "kitchenowl-web" on the compose network; compose.kitchenowl.yml
+# provides exactly that.
+
+{
+	email {$KORBKLAR_ACME_EMAIL}
+}
+
+import /etc/caddy/sites/korbklar.caddy
+import /etc/caddy/sites/kitchenowl.caddy

--- a/deploy/caddy/sites/kitchenowl.caddy
+++ b/deploy/caddy/sites/kitchenowl.caddy
@@ -1,0 +1,26 @@
+# KitchenOwl on its own domain. Its Flutter frontend and the live updates
+# between household members rely on WebSockets, which reverse_proxy upgrades
+# on its own.
+{$KORBKLAR_KITCHENOWL_DOMAIN} {
+	encode zstd gzip
+
+	# The frontend image already proxies /api to the backend, so one upstream
+	# is enough here.
+	reverse_proxy kitchenowl-web:80 {
+		header_up X-Forwarded-For {remote_host}
+		header_up X-Real-IP {remote_host}
+		header_up X-Forwarded-Proto {scheme}
+		header_up Host {host}
+	}
+
+	header {
+		Strict-Transport-Security "max-age=31536000; includeSubDomains"
+		X-Content-Type-Options "nosniff"
+		-Server
+	}
+
+	log {
+		output stderr
+		format console
+	}
+}

--- a/deploy/caddy/sites/korbklar.caddy
+++ b/deploy/caddy/sites/korbklar.caddy
@@ -1,0 +1,38 @@
+{$KORBKLAR_DOMAIN} {
+	encode zstd gzip
+
+	# The browser interface has no login of its own; SUPERMARKT_API_KEY guards
+	# the REST routes only. Facing the internet, either keep this domain for a
+	# VPN or enable the block below. The hash comes from
+	#   docker compose exec caddy caddy hash-password
+	# and goes into .env as KORBKLAR_BASIC_AUTH_HASH.
+	#
+	# basic_auth {
+	# 	korbklar {$KORBKLAR_BASIC_AUTH_HASH}
+	# }
+
+	reverse_proxy korbklar:8000 {
+		# Overwrite rather than append. Caddy would otherwise keep whatever the
+		# client sent and add the real address behind it. Setting the header to
+		# the immediate peer makes it say exactly one thing, so nothing behind
+		# the proxy can be talked into believing a client-chosen address.
+		header_up X-Forwarded-For {remote_host}
+		header_up X-Real-IP {remote_host}
+		header_up X-Forwarded-Proto {scheme}
+		header_up Host {host}
+	}
+
+	header {
+		# Caddy already redirects to HTTPS; this tells browsers to skip the
+		# plaintext attempt next time.
+		Strict-Transport-Security "max-age=31536000; includeSubDomains"
+		X-Content-Type-Options "nosniff"
+		Referrer-Policy "no-referrer"
+		-Server
+	}
+
+	log {
+		output stderr
+		format console
+	}
+}

--- a/docs/README.md
+++ b/docs/README.md
@@ -1,0 +1,10 @@
+# Dokumentation · Documentation
+
+Die README beschreibt, was KorbKlar tut. Diese Seiten beschreiben, wie man es
+betreibt. / The README says what KorbKlar does. These pages say how to run it.
+
+| Thema · Topic | Deutsch | English |
+| --- | --- | --- |
+| Deployment, Compose-Dateien, HTTPS mit Caddy | [deployment.de.md](deployment.de.md) | [deployment.en.md](deployment.en.md) |
+
+Die Android-App hat ihre eigene Anleitung in [../app/README.md](../app/README.md).

--- a/docs/deployment.de.md
+++ b/docs/deployment.de.md
@@ -1,0 +1,128 @@
+# Deployment
+
+[English](deployment.en.md)
+
+KorbKlar läuft als ein Container. Alles Optionale hat seine eigene
+Compose-Datei, damit eine Installation, die nichts davon braucht, nur
+`compose.yml` lesen und starten muss.
+
+| Datei | Bringt | Pflicht in `.env` |
+| --- | --- | --- |
+| `compose.yml` | KorbKlar | nichts |
+| `compose.proxy.yml` | Caddy mit Let's-Encrypt-Zertifikaten | `KORBKLAR_DOMAIN`, `KORBKLAR_ACME_EMAIL` |
+
+Die Dateien werden kombiniert, nicht ausgewählt:
+
+```bash
+docker compose up -d
+docker compose -f compose.yml -f compose.proxy.yml up -d
+```
+
+Die Reihenfolge zählt: `compose.yml` kommt zuerst, die Overlays ergänzen sie.
+Eine Kombination, die bleibt, steht einmal in der `.env`; danach genügt wieder
+ein blankes `docker compose up -d`, auch für `pull`, `logs` und `down`:
+
+```bash
+COMPOSE_FILE=compose.yml:compose.proxy.yml
+```
+
+Getrennt wird mit `:` unter Linux und macOS, mit `;` unter Windows.
+
+Fehlt ein Pflichtwert, scheitert schon `docker compose config` und nennt die
+Variable. Ohne das zugehörige Overlay wird sie gar nicht erst gelesen; eine
+Installation ohne HTTPS braucht also keine Domain.
+
+## Nur KorbKlar
+
+```bash
+docker compose up -d
+```
+
+Erreichbar unter `http://<host>:8000`. `SUPERMARKT_PORT` ändert den Host-Port,
+der Container bleibt auf 8000. Eine `.env` ist dafür nicht nötig.
+
+## Mit HTTPS
+
+```bash
+cp .env.example .env
+# in der .env:
+KORBKLAR_DOMAIN=korbklar.deine-domain.example
+KORBKLAR_ACME_EMAIL=du@deine-domain.example
+
+docker compose -f compose.yml -f compose.proxy.yml up -d
+```
+
+Caddy holt und erneuert die Zertifikate selbst; es gibt keinen
+certbot-Container und keinen Cron-Job. Vor dem ersten Start muss ein A- oder
+AAAA-Record auf den Server zeigen und Port 80 und 443 müssen erreichbar sein.
+Darüber prüft Let's Encrypt.
+
+Mit dem Proxy davor wird KorbKlars eigener Port nicht mehr auf jeder
+Schnittstelle veröffentlicht. Das Overlay bindet ihn auf `127.0.0.1` um, damit
+`curl http://127.0.0.1:8000/health` auf dem Host weiter funktioniert und
+trotzdem niemand an der Verschlüsselung vorbeikommt. Dafür braucht es Docker
+Compose v2.24 oder neuer, das den vom Overlay genutzten `!override`-Tag
+eingeführt hat.
+
+Die Browser-Oberfläche hat keine eigene Anmeldung: `SUPERMARKT_API_KEY` schützt
+die REST-Routen, nicht die Seiten. Eine Domain, die ins Internet zeigt, will
+deshalb eines von zwei Dingen. Entweder sie bleibt nur für ein VPN erreichbar,
+oder der `basic_auth`-Block in `deploy/caddy/sites/korbklar.caddy` wird
+eingeschaltet:
+
+```bash
+docker compose exec caddy caddy hash-password
+# Ergebnis in die .env:
+KORBKLAR_BASIC_AUTH_HASH=$2a$14$...
+```
+
+### Einen Klartext-Weg fürs VPN behalten
+
+Wer im VPN ist, kann KorbKlar weiter über HTTP nutzen, ohne
+Zertifikatswarnung und ohne Passwortabfrage: `KORBKLAR_BIND_ADDRESS` auf die
+VPN-Adresse des Hosts zeigen lassen statt auf `127.0.0.1`.
+
+```bash
+KORBKLAR_BIND_ADDRESS=10.8.0.1
+```
+
+Port 8000 wird dann nur auf dieser Schnittstelle veröffentlicht. Das Internet
+erreicht den Proxy, das VPN den Container direkt, und beide Wege bleiben
+getrennt.
+
+### Eine zweite Domain
+
+`deploy/caddy/Caddyfile.kitchenowl` bedient neben KorbKlar eine KitchenOwl im
+selben Compose-Projekt auf einer eigenen Domain. Es erwartet, dass der
+KitchenOwl-Web-Container im Compose-Netz als `kitchenowl-web` antwortet, was
+ein KitchenOwl-Overlay für dieses Compose-Projekt bereitstellt.
+
+```bash
+KORBKLAR_CADDYFILE=./deploy/caddy/Caddyfile.kitchenowl
+KORBKLAR_KITCHENOWL_DOMAIN=liste.deine-domain.example
+```
+
+Die zweite Domain braucht ebenfalls einen eigenen DNS-Eintrag, sonst bekommt
+Caddy kein Zertifikat. Beide Einstiegsdateien unter `deploy/caddy/`
+importieren dieselben Site-Dateien aus `deploy/caddy/sites/`, die Proxy-Regeln
+stehen also genau einmal.
+
+### Was der Proxy weiterreicht
+
+Caddy **überschreibt** ein vom Client mitgeschicktes `X-Forwarded-For` mit der
+tatsächlichen Gegenstelle, statt es zu ergänzen. Nichts hinter dem Proxy lässt
+sich so eine vom Client gewählte Adresse unterschieben. uvicorn selbst glaubt
+Forwarding-Headern nur von `127.0.0.1`, was der Caddy-Container nie ist;
+KorbKlar sieht also den Proxy als Gegenstelle.
+
+## Aktualisieren
+
+```bash
+docker compose pull
+docker compose up -d
+```
+
+Das Volume `korbklar-data` übersteht das. Es enthält den Snapshot-Cache, die
+Bilder und den Signierschlüssel für Ergebnislinks; den letzten behalten, sonst
+funktionieren bereits verschickte Ergebnislinks nicht mehr. Die Zertifikate
+liegen in `caddy-data` und bleiben ebenfalls erhalten.

--- a/docs/deployment.en.md
+++ b/docs/deployment.en.md
@@ -1,0 +1,124 @@
+# Deployment
+
+[Deutsch](deployment.de.md)
+
+KorbKlar runs as one container. Everything optional lives in its own compose
+file, so an installation that needs none of it reads and starts only
+`compose.yml`.
+
+| File | Adds | Required in `.env` |
+| --- | --- | --- |
+| `compose.yml` | KorbKlar | none |
+| `compose.proxy.yml` | Caddy with Let's Encrypt certificates | `KORBKLAR_DOMAIN`, `KORBKLAR_ACME_EMAIL` |
+
+The files are combined, not chosen between:
+
+```bash
+docker compose up -d
+docker compose -f compose.yml -f compose.proxy.yml up -d
+```
+
+Order matters: `compose.yml` comes first and the overlays add to it. For a
+combination you keep, state it once in `.env` and a bare `docker compose up -d`
+is enough again, for `pull`, `logs` and `down` as well:
+
+```bash
+COMPOSE_FILE=compose.yml:compose.proxy.yml
+```
+
+The separator is `:` on Linux and macOS, `;` on Windows.
+
+A missing required value fails `docker compose config` already and names the
+variable. Without its overlay it is never read at all, so an installation
+without HTTPS needs no domain.
+
+## KorbKlar alone
+
+```bash
+docker compose up -d
+```
+
+Reachable on `http://<host>:8000`. `SUPERMARKT_PORT` changes the host port;
+the container stays on 8000. No `.env` is needed for this.
+
+## With HTTPS
+
+```bash
+cp .env.example .env
+# in .env:
+KORBKLAR_DOMAIN=korbklar.your-domain.example
+KORBKLAR_ACME_EMAIL=you@your-domain.example
+
+docker compose -f compose.yml -f compose.proxy.yml up -d
+```
+
+Caddy obtains and renews the certificates itself, with no certbot container
+and no cron job. Before the first start an A or AAAA record must point at the
+server and ports 80 and 443 must be reachable — that is what Let's Encrypt
+checks over.
+
+With the proxy in place KorbKlar's own port is no longer published on every
+interface. The overlay rebinds it to `127.0.0.1`, so `curl
+http://127.0.0.1:8000/health` on the host keeps working while nobody can walk
+around the encryption. This needs Docker Compose v2.24 or newer, which
+introduced the `!override` tag the overlay uses.
+
+The browser interface has no login of its own: `SUPERMARKT_API_KEY` guards the
+REST routes, not the pages. A domain that faces the internet therefore wants
+one of two things. Either it stays reachable for a VPN only, or the
+`basic_auth` block in `deploy/caddy/sites/korbklar.caddy` is enabled:
+
+```bash
+docker compose exec caddy caddy hash-password
+# paste the result into .env:
+KORBKLAR_BASIC_AUTH_HASH=$2a$14$...
+```
+
+### Keeping a plain path for the VPN
+
+Someone on a VPN can keep using KorbKlar over plain HTTP without a certificate
+warning and without a password prompt: point `KORBKLAR_BIND_ADDRESS` at the
+VPN address of the host instead of `127.0.0.1`.
+
+```bash
+KORBKLAR_BIND_ADDRESS=10.8.0.1
+```
+
+Port 8000 is then published on that interface only. The internet reaches the
+proxy, the VPN reaches the container directly, and the two paths stay apart.
+
+### A second domain
+
+`deploy/caddy/Caddyfile.kitchenowl` serves a KitchenOwl in the same compose
+project on its own domain next to KorbKlar. It expects the KitchenOwl web
+container to answer as `kitchenowl-web` on the compose network, which is what
+a KitchenOwl overlay for this compose project provides.
+
+```bash
+KORBKLAR_CADDYFILE=./deploy/caddy/Caddyfile.kitchenowl
+KORBKLAR_KITCHENOWL_DOMAIN=list.your-domain.example
+```
+
+The second domain needs its own DNS record too, or Caddy gets no certificate.
+Both entry points under `deploy/caddy/` import the same site files from
+`deploy/caddy/sites/`, so the proxy rules exist in exactly one place.
+
+### What the proxy forwards
+
+Caddy **overwrites** a client-supplied `X-Forwarded-For` with the actual peer
+rather than appending to it. Nothing behind the proxy can be talked into
+believing an address the client chose. uvicorn itself only trusts forwarding
+headers from `127.0.0.1`, which the Caddy container never is, so KorbKlar sees
+the proxy as its peer.
+
+## Updating
+
+```bash
+docker compose pull
+docker compose up -d
+```
+
+The `korbklar-data` volume survives this. It holds the snapshot cache, the
+images and the signing key for result links; keep the last one, or result
+links already sent out stop working. The certificates live in `caddy-data` and
+survive as well.

--- a/tests/test_release_cleanliness.py
+++ b/tests/test_release_cleanliness.py
@@ -147,20 +147,63 @@ def test_release_has_no_development_machine_references():
         assert marker not in text
 
 
-def test_release_has_only_the_base_compose_file():
+def test_release_carries_no_stray_compose_file():
     compose_files = sorted(path.name for path in ROOT.glob("compose*.yml"))
-    assert compose_files == ["compose.yml"]
-    compose = (ROOT / "compose.yml").read_text(encoding="utf-8")
-    assert "supermarkt-ts" not in compose
+    assert compose_files == ["compose.proxy.yml", "compose.yml"]
+    for name in compose_files:
+        assert "supermarkt-ts" not in (ROOT / name).read_text(encoding="utf-8")
 
 
 def test_all_supported_compose_environment_variables_are_documented():
-    compose = (ROOT / "compose.yml").read_text(encoding="utf-8")
+    compose = "\n".join(
+        path.read_text(encoding="utf-8") for path in sorted(ROOT.glob("compose*.yml"))
+    )
     env_example = (ROOT / ".env.example").read_text(encoding="utf-8")
-    names = set(re.findall(r"\$\{(SUPERMARKT_[A-Z0-9_]+)", compose))
+    names = set(re.findall(r"\$\{((?:SUPERMARKT|KORBKLAR)_[A-Z0-9_]+)", compose))
     names.add("SUPERMARKT_PORT")
     for name in names:
         assert f"{name}=" in env_example, name
+
+
+def test_the_proxy_is_a_separate_compose_file():
+    """TLS must never be needed to run the comparison."""
+    base = (ROOT / "compose.yml").read_text(encoding="utf-8")
+    assert "caddy" not in base.casefold()
+    overlay = (ROOT / "compose.proxy.yml").read_text(encoding="utf-8")
+    # The overlay adds to the base rather than repeating it, and it takes the
+    # published port off the public interfaces instead of adding a second one.
+    assert "image: ghcr.io/lesecuritae/korbklar" not in overlay
+    assert "ports: !override" in overlay
+    assert "${KORBKLAR_BIND_ADDRESS:-127.0.0.1}:${SUPERMARKT_PORT:-8000}:8000" in overlay
+    assert "condition: service_healthy" in overlay
+
+
+def test_the_proxy_never_forwards_a_client_supplied_source_address():
+    site = (ROOT / "deploy/caddy/sites/korbklar.caddy").read_text(encoding="utf-8")
+    # Overwriting rather than appending is what keeps anything behind the
+    # proxy from ever seeing an address the client chose.
+    assert "header_up X-Forwarded-For {remote_host}" in site
+    assert "{$KORBKLAR_DOMAIN}" in site
+    for name in ("Caddyfile", "Caddyfile.kitchenowl"):
+        entry = (ROOT / "deploy/caddy" / name).read_text(encoding="utf-8")
+        assert "{$KORBKLAR_ACME_EMAIL}" in entry
+        # Both entry points import the same site file, so the header handling
+        # above cannot drift apart between them.
+        assert "import /etc/caddy/sites/korbklar.caddy" in entry
+
+
+def test_every_relative_documentation_link_resolves():
+    """A moved section must not leave a dead link behind."""
+    pages = [ROOT / "README.md", ROOT / "README.de.md", ROOT / "README.en.md"]
+    pages += sorted((ROOT / "docs").glob("*.md"))
+    broken = []
+    for page in pages:
+        broken.extend(
+            f"{page.name} -> {target}"
+            for target in re.findall(r"\]\(([^)#:]+\.md)\)", page.read_text(encoding="utf-8"))
+            if not (page.parent / target).resolve().is_file()
+        )
+    assert not broken, broken
 
 
 def test_release_has_no_private_or_internal_revision_markers():


### PR DESCRIPTION
## What this adds

An optional second compose file, `compose.proxy.yml`, that puts Caddy in front of KorbKlar and lets it obtain and renew Let's Encrypt certificates on its own. Nothing changes for a plain installation: the overlay is *added* to `compose.yml`, never used instead of it, and without it no domain is read and no container created.

```bash
docker compose -f compose.yml -f compose.proxy.yml up -d
# or once in .env:
COMPOSE_FILE=compose.yml:compose.proxy.yml
```

Required in `.env` only when the overlay is present: `KORBKLAR_DOMAIN`, `KORBKLAR_ACME_EMAIL`. Missing values fail `docker compose config` with a message naming the variable.

## Design decisions

- **KorbKlar's own port is taken off the public interfaces** when the proxy is on. The overlay uses Compose's `ports: !override` to rebind it to `127.0.0.1` (so `curl http://127.0.0.1:8000/health` on the host keeps working) instead of leaving `0.0.0.0:8000` published next to the TLS endpoint. `KORBKLAR_BIND_ADDRESS` can point it at a VPN address instead, which keeps a plain-HTTP path for the VPN while the internet only reaches Caddy. This needs Compose v2.24+ (Jan 2024). `compose.yml` itself is untouched.
- **Caddy overwrites `X-Forwarded-For`** with the real peer rather than appending, so nothing behind the proxy can be handed a client-chosen address.
- **The browser UI has no login of its own**, and this PR does not pretend otherwise. The docs say so and `deploy/caddy/sites/korbklar.caddy` carries a ready-to-enable `basic_auth` block (`KORBKLAR_BASIC_AUTH_HASH`, from `caddy hash-password`) for a domain that faces the internet.
- **Optional second domain**: `deploy/caddy/Caddyfile.kitchenowl` (selected via `KORBKLAR_CADDYFILE`) additionally serves a KitchenOwl web container reachable as `kitchenowl-web` in the same compose project. Both entry points import the same site files under `deploy/caddy/sites/`, so the proxy rules exist once. The KitchenOwl overlay itself is a separate PR.

## Files

- `compose.proxy.yml`, `deploy/caddy/{Caddyfile,Caddyfile.kitchenowl}`, `deploy/caddy/sites/{korbklar,kitchenowl}.caddy`
- `docs/deployment.{de,en}.md` (compose combinations, `COMPOSE_FILE`, HTTPS, VPN split, second domain, updating), `docs/README.md`
- `.env.example`: header explaining the compose files, new `KORBKLAR_*` section
- README (de/en): short "HTTPS with Caddy" section linking to the docs
- `tests/test_release_cleanliness.py`: the compose-file list and the env-documentation check now cover the overlay; new checks that the proxy overwrites `X-Forwarded-For`, that both Caddyfiles import the shared site file, that the overlay rebinds the port, and that every relative docs link resolves
- `.github/workflows/tests.yml`: the smoke test now asserts the overlay refuses to start without a domain and rebinds to `127.0.0.1` with one

## Tested

- `docker compose -f compose.yml -f compose.proxy.yml config` with and without the domain, and with `Caddyfile.kitchenowl` selected
- `caddy validate` against both entry points inside `caddy:2-alpine`
- `pytest -m 'not live'`: everything this PR touches passes. Seven tests fail on my Windows checkout of upstream `main` *before* this change as well (node stdout encoding in `test_shopping_list.py` / `test_keyword_filters.py`, file-permission check in `test_security.py`, and `test_region.py` tripping the `04209` marker in `test_release_cleanliness.py`); they are unrelated and left alone.

## Disclosure

Written with AI assistance (Claude), reviewed and adjusted by me. The compose/Caddy layout is what I have been running on my own fork for a few weeks; this is the upstream-clean version without fork-specific pieces.
