### PR TITLE
app: open the last comparison on start and refresh by offer week

### DIFF
--- a/app/README.md
+++ b/app/README.md
@@ -23,8 +23,9 @@ price; it renders the values the comparison engine returns.
 - local result cache: previously loaded offers remain searchable without a server
 - persistent local shopping list with offline view and clipboard export
 - direct optional KitchenOwl connection, independent of the KorbKlar server
-- a refresh action that bypasses the server's snapshot cache and re-queries
-  every source
+- opens straight into the last comparison and re-queries the retailers only
+  after an offer change (Monday, Thursday), see below
+- a refresh action that starts a new search by hand
 
 Server address, postal code, loyalty selection and target list are remembered
 on the device. KorbKlar and KitchenOwl tokens are stored in Android's encrypted
@@ -38,6 +39,26 @@ If no postcode has been saved, Android asks whether the current location may be
 used. Reverse geocoding runs through the device service; only the resulting
 five-digit postcode is stored. Location permission can be denied without
 losing any manual-search or offline feature.
+
+## Starting
+
+The postal code rarely changes, so the app does not ask for it every time.
+With a saved postcode and a connected server it opens **straight into the
+last comparison**: the stored result is shown at once, from the device cache
+if the server is unreachable.
+
+Whether the retailers are queried again is decided by the calendar, not by
+how long the app was closed. German offers change on **Monday** and, for the
+discounters, again on **Thursday**. If one of those lies between the last
+search and now, a fresh search starts in the background while the old result
+stays readable; a slim strip above the list shows its progress and the new
+result replaces the old one when it completes. Between changes the app opens
+in a second and makes no request at all beyond reading the stored result.
+
+A different postcode is one tap away: the **PLZ** title of the result list
+leads back to the search form. The behaviour can be switched off under
+**Settings → Start**; the refresh icon in the result list always starts a new
+search by hand.
 
 ## Shopping list
 

--- a/app/README.md
+++ b/app/README.md
@@ -24,7 +24,7 @@ price; it renders the values the comparison engine returns.
 - persistent local shopping list with offline view and clipboard export
 - direct optional KitchenOwl connection, independent of the KorbKlar server
 - opens straight into the last comparison and re-queries the retailers only
-  after an offer change (Monday, Thursday), see below
+  after an offer change (Thursday, and Sunday for the new week), see below
 - a refresh action that starts a new search by hand
 
 Server address, postal code, loyalty selection and target list are remembered
@@ -48,8 +48,9 @@ last comparison**: the stored result is shown at once, from the device cache
 if the server is unreachable.
 
 Whether the retailers are queried again is decided by the calendar, not by
-how long the app was closed. German offers change on **Monday** and, for the
-discounters, again on **Thursday**. If one of those lies between the last
+how long the app was closed. German offers change for the new week, which the
+server already selects on **Sunday**, and for the discounters again on
+**Thursday**. If one of those lies between the last
 search and now, a fresh search starts in the background while the old result
 stays readable; a slim strip above the list shows its progress and the new
 result replaces the old one when it completes. Between changes the app opens

--- a/app/lib/screens/home_screen.dart
+++ b/app/lib/screens/home_screen.dart
@@ -7,6 +7,7 @@ import '../api/client.dart';
 import '../api/models.dart';
 import '../main.dart';
 import '../services/settings.dart';
+import '../services/offer_week.dart';
 import '../services/offline_store.dart';
 import '../services/local_shopping_list.dart';
 import '../services/postal_location.dart';
@@ -68,6 +69,7 @@ class _HomeScreenState extends State<HomeScreen> with WidgetsBindingObserver {
   bool _busy = false;
   bool _offlineAvailable = false;
   bool _locating = false;
+  bool _autoStarted = false;
   late List<String> _selectedRetailers = [...widget.settings.selectedRetailers];
 
   /// The search running on the server, kept so a lost connection can be
@@ -119,6 +121,73 @@ class _HomeScreenState extends State<HomeScreen> with WidgetsBindingObserver {
     await _checkOffline();
     if (mounted && _postalCode.text.isEmpty) await _useLocation();
     if (mounted) setState(() {});
+    await _maybeAutoStart();
+  }
+
+  /// Opens the comparison for the remembered postal code without asking.
+  ///
+  /// Runs once per app start. The stored result is shown first; whether the
+  /// retailers are queried again depends on whether an offer change (Monday
+  /// or Thursday) lies between that search and now, not on how long the app
+  /// was closed. A different postal code is one tap away from the results.
+  Future<void> _maybeAutoStart() async {
+    if (_autoStarted || !mounted || _busy) return;
+    if (!widget.settings.autoStart || !_serverConfigured) return;
+    final postalCode = _postalCode.text.trim();
+    if (!RegExp(r'^\d{5}$').hasMatch(postalCode)) return;
+    _autoStarted = true;
+
+    final last = widget.settings.lastSearch;
+    if (last != null && last.matches(postalCode, _selectedRetailers)) {
+      await _openResults(
+        handle: last.handle,
+        refresh: OfferWeek.isStale(last.searchedAt),
+      );
+      return;
+    }
+    if (await widget.offlineStore.hasPostalCode(postalCode)) {
+      // Something to look at while the server works through the sources.
+      await _openResults(handle: _offlineHandle, refresh: true);
+      return;
+    }
+    await _search();
+  }
+
+  static const _offlineHandle = ResultHandle(
+    searchId: 'offline',
+    token: 'offline',
+  );
+
+  /// Shows a result. With [refresh] the screen starts a new search for the
+  /// same postal code in the background and swaps it in when it completes.
+  Future<void> _openResults({
+    required ResultHandle handle,
+    bool refresh = false,
+  }) async {
+    if (!mounted) return;
+    // Without a server the stored pages are all there is; the client then
+    // points nowhere and the results screen falls back to the offline store.
+    final client = _serverConfigured
+        ? KorbKlarClient(
+            baseUrl: widget.settings.serverUrl,
+            apiKey: widget.settings.apiKey,
+          )
+        : KorbKlarClient(baseUrl: 'http://127.0.0.1:1');
+    await Navigator.of(context).push(
+      MaterialPageRoute<void>(
+        builder: (_) => ResultsScreen(
+          client: client,
+          handle: handle,
+          settings: widget.settings,
+          offlineStore: widget.offlineStore,
+          localShoppingList: widget.localShoppingList,
+          retailers: _selectedRetailers,
+          autoRefresh: refresh && _serverConfigured,
+        ),
+      ),
+    );
+    client.close();
+    await _checkOffline();
   }
 
   Future<void> _useLocation() async {
@@ -154,21 +223,8 @@ class _HomeScreenState extends State<HomeScreen> with WidgetsBindingObserver {
     if (mounted) setState(() => _offlineAvailable = available);
   }
 
-  Future<void> _openOffline() async {
-    final client = KorbKlarClient(baseUrl: 'http://127.0.0.1:1');
-    await Navigator.of(context).push(
-      MaterialPageRoute<void>(
-        builder: (_) => ResultsScreen(
-          client: client,
-          handle: const ResultHandle(searchId: 'offline', token: 'offline'),
-          settings: widget.settings,
-          offlineStore: widget.offlineStore,
-          localShoppingList: widget.localShoppingList,
-        ),
-      ),
-    );
-    client.close();
-  }
+  Future<void> _openOffline() =>
+      _openResults(handle: _offlineHandle, refresh: false);
 
   @override
   void dispose() {
@@ -399,6 +455,17 @@ class _HomeScreenState extends State<HomeScreen> with WidgetsBindingObserver {
               _busy = false;
               _jobId = '';
             });
+            // Remembered so the next start opens this result directly.
+            await widget.settings.setLastSearch(
+              LastSearch(
+                postalCode: widget.settings.postalCode,
+                retailers: _selectedRetailers,
+                searchId: handle.searchId,
+                token: handle.token,
+                searchedAt: DateTime.now(),
+              ),
+            );
+            if (!mounted) return;
             await Navigator.of(context).push(
               MaterialPageRoute<void>(
                 builder: (_) => ResultsScreen(
@@ -407,10 +474,12 @@ class _HomeScreenState extends State<HomeScreen> with WidgetsBindingObserver {
                   settings: widget.settings,
                   offlineStore: widget.offlineStore,
                   localShoppingList: widget.localShoppingList,
+                  retailers: _selectedRetailers,
                 ),
               ),
             );
             _finish();
+            await _checkOffline();
           },
           onError: (Object error) {
             if (!mounted) return;

--- a/app/lib/screens/home_screen.dart
+++ b/app/lib/screens/home_screen.dart
@@ -127,8 +127,8 @@ class _HomeScreenState extends State<HomeScreen> with WidgetsBindingObserver {
   /// Opens the comparison for the remembered postal code without asking.
   ///
   /// Runs once per app start. The stored result is shown first; whether the
-  /// retailers are queried again depends on whether an offer change (Monday
-  /// or Thursday) lies between that search and now, not on how long the app
+  /// retailers are queried again depends on whether an offer change (Thursday,
+  /// or Sunday for the new week) lies between that search and now, not on how long the app
   /// was closed. A different postal code is one tap away from the results.
   Future<void> _maybeAutoStart() async {
     if (_autoStarted || !mounted || _busy) return;

--- a/app/lib/screens/results_screen.dart
+++ b/app/lib/screens/results_screen.dart
@@ -7,6 +7,7 @@ import '../api/client.dart';
 import '../api/kitchenowl_client.dart';
 import '../api/models.dart';
 import '../services/settings.dart';
+import '../services/offer_week.dart';
 import '../services/offline_store.dart';
 import '../services/local_shopping_list.dart';
 import '../theme.dart';
@@ -31,6 +32,8 @@ class ResultsScreen extends StatefulWidget {
     required this.settings,
     required this.offlineStore,
     required this.localShoppingList,
+    this.retailers = const [],
+    this.autoRefresh = false,
   });
 
   final KorbKlarClient client;
@@ -38,6 +41,13 @@ class ResultsScreen extends StatefulWidget {
   final Settings settings;
   final OfflineStore offlineStore;
   final LocalShoppingListStore localShoppingList;
+
+  /// Retailer selection the search was made with; reused for a fresh one.
+  final List<String> retailers;
+
+  /// Start a new search for the same postal code right away and swap it in
+  /// when it completes, while [handle] (or the offline store) is shown.
+  final bool autoRefresh;
 
   @override
   State<ResultsScreen> createState() => _ResultsScreenState();
@@ -49,6 +59,16 @@ class _ResultsScreenState extends State<ResultsScreen> {
   final _offers = <Offer>[];
 
   ResultPage? _page;
+
+  /// The comparison currently shown. Starts as the one handed in and moves
+  /// on when a fresh search for the same postal code completes.
+  late ResultHandle _handle = widget.handle;
+
+  /// A fresh search running on the server while older data stays visible.
+  StreamSubscription<SearchProgress>? _refreshWatch;
+  SearchProgress? _refreshProgress;
+  String _refreshError = '';
+  bool get _refreshRunning => _refreshWatch != null;
 
   /// Offers filed in this session: offer key to article name.
   final _filed = <String, String>{};
@@ -84,11 +104,13 @@ class _ResultsScreenState extends State<ResultsScreen> {
     _scroll.addListener(_onScroll);
     _reload();
     _loadShoppingList();
+    if (widget.autoRefresh) _startFreshSearch();
   }
 
   @override
   void dispose() {
     _debounce?.cancel();
+    _refreshWatch?.cancel();
     _directKitchenOwl?.close();
     _scroll.dispose();
     _search.dispose();
@@ -125,7 +147,7 @@ class _ResultsScreenState extends State<ResultsScreen> {
       }
     }
     try {
-      final info = await widget.client.shoppingListTargets(widget.handle);
+      final info = await widget.client.shoppingListTargets(_handle);
       if (!mounted) return;
       final known = info.targets.map((target) => target.entityId).toSet();
       final remembered = widget.settings.shoppingListEntity;
@@ -177,7 +199,7 @@ class _ResultsScreenState extends State<ResultsScreen> {
         sort: _sort,
       );
       final page = await widget.client.results(
-        widget.handle,
+        _handle,
         filterText: _search.text,
         retailer: _retailer,
         category: _category,
@@ -245,6 +267,85 @@ class _ResultsScreenState extends State<ResultsScreen> {
     if (mounted) setState(() => _refreshing = false);
   }
 
+  /// Starts a new search for the same postal code and swaps the result in
+  /// once it completes.
+  ///
+  /// What is on screen stays on screen meanwhile: a comparison from before
+  /// Thursday is still a comparison, only not the current one. The server's
+  /// snapshot cache decides whether the retailers are actually queried again,
+  /// so within its window this is one request and a few seconds; after an
+  /// offer change it takes as long as any search.
+  Future<void> _startFreshSearch() async {
+    if (_refreshRunning) return;
+    final postalCode = widget.settings.postalCode;
+    if (!RegExp(r'^\d{5}$').hasMatch(postalCode)) return;
+    setState(() {
+      _refreshError = '';
+      _refreshProgress = null;
+    });
+    String jobId;
+    try {
+      jobId = await widget.client.startSearch(
+        postalCode,
+        retailers: widget.retailers,
+      );
+    } on KorbKlarException catch (exception) {
+      if (mounted) setState(() => _refreshError = exception.message);
+      return;
+    }
+    if (!mounted) return;
+    _refreshWatch = widget.client
+        .watchSearch(jobId)
+        .listen(
+          (progress) async {
+            if (!mounted) return;
+            setState(() => _refreshProgress = progress);
+            if (progress.isFailed) {
+              _endRefresh(
+                progress.error.isNotEmpty
+                    ? progress.error
+                    : 'Die Suche ist fehlgeschlagen.',
+              );
+              return;
+            }
+            if (!progress.isDone) return;
+            final handle = ResultHandle.parse(progress.resultPath);
+            if (handle == null) {
+              _endRefresh('Der Server lieferte keinen gültigen Ergebnislink.');
+              return;
+            }
+            await widget.settings.setLastSearch(
+              LastSearch(
+                postalCode: postalCode,
+                retailers: widget.retailers,
+                searchId: handle.searchId,
+                token: handle.token,
+                searchedAt: DateTime.now(),
+              ),
+            );
+            if (!mounted) return;
+            _handle = handle;
+            _endRefresh('');
+            _reload();
+            await _reconcileFiled();
+          },
+          onError: (Object error) {
+            if (!mounted) return;
+            _endRefresh(error is KorbKlarException ? error.message : '$error');
+          },
+        );
+    setState(() {});
+  }
+
+  void _endRefresh(String error) {
+    _refreshWatch?.cancel();
+    _refreshWatch = null;
+    setState(() {
+      _refreshProgress = null;
+      _refreshError = error;
+    });
+  }
+
   /// Drops offers whose article was checked off in KitchenOwl meanwhile.
   ///
   /// Checking an entry off removes it there, so the app must not keep
@@ -252,7 +353,7 @@ class _ResultsScreenState extends State<ResultsScreen> {
   Future<void> _reconcileFiled() async {
     if (_listId.isEmpty) return;
     try {
-      final pending = await widget.client.listEntries(widget.handle, _listId);
+      final pending = await widget.client.listEntries(_handle, _listId);
       if (!mounted) return;
       setState(() {
         _filed.removeWhere((_, article) => !pending.contains(article));
@@ -296,7 +397,7 @@ class _ResultsScreenState extends State<ResultsScreen> {
       final added = direct != null
           ? [await direct.addOffer(entity, offer)]
           : await widget.client.addToShoppingList(
-              widget.handle,
+              _handle,
               entityId: entity,
               offers: [offer],
             );
@@ -475,9 +576,32 @@ class _ResultsScreenState extends State<ResultsScreen> {
       appBar: AppBar(
         backgroundColor: colors.bg,
         surfaceTintColor: Colors.transparent,
-        title: Text(
-          page == null ? 'Angebote' : 'PLZ ${page.postalCode}',
-          style: const TextStyle(fontWeight: FontWeight.w700),
+        // The title doubles as the way to a different postal code: with the
+        // app opening straight into the results, this is where a user looks.
+        title: Tooltip(
+          message: 'Neue Suche mit anderer PLZ',
+          child: InkWell(
+            borderRadius: BorderRadius.circular(8),
+            onTap: () => Navigator.of(context).maybePop(),
+            child: Padding(
+              padding: const EdgeInsets.symmetric(horizontal: 4, vertical: 6),
+              child: Row(
+                mainAxisSize: MainAxisSize.min,
+                children: [
+                  Text(
+                    page == null ? 'Angebote' : 'PLZ ${page.postalCode}',
+                    style: const TextStyle(fontWeight: FontWeight.w700),
+                  ),
+                  const SizedBox(width: 6),
+                  Icon(
+                    Icons.edit_location_alt_outlined,
+                    size: 18,
+                    color: colors.muted,
+                  ),
+                ],
+              ),
+            ),
+          ),
         ),
         actions: [
           if (_offline)
@@ -487,9 +611,15 @@ class _ResultsScreenState extends State<ResultsScreen> {
             ),
           LocalShoppingListButton(store: widget.localShoppingList),
           IconButton(
-            tooltip: 'Ergebnisse neu laden',
-            onPressed: _refreshing || page == null ? null : _refreshFromCache,
-            icon: _refreshing
+            tooltip: _offline
+                ? 'Gespeicherte Ergebnisse neu lesen'
+                : 'Angebote neu laden',
+            onPressed: _refreshing || _refreshRunning
+                ? null
+                : _offline
+                ? _refreshFromCache
+                : _startFreshSearch,
+            icon: _refreshing || _refreshRunning
                 ? const SizedBox(
                     height: 18,
                     width: 18,
@@ -521,6 +651,14 @@ class _ResultsScreenState extends State<ResultsScreen> {
       body: Column(
         children: [
           _controls(colors),
+          if (_refreshRunning || _refreshError.isNotEmpty)
+            _RefreshBanner(
+              progress: _refreshProgress,
+              error: _refreshError,
+              stale: widget.autoRefresh,
+              onRetry: _startFreshSearch,
+              onDismiss: () => setState(() => _refreshError = ''),
+            ),
           if (_shoppingList.configured && _shoppingList.targets.isNotEmpty)
             _listBar(colors),
           if (page != null) _chips(page, colors),
@@ -750,6 +888,115 @@ class _ResultsScreenState extends State<ResultsScreen> {
             fontSize: 13,
           ),
         ),
+      ),
+    );
+  }
+}
+
+/// A slim strip above the list while a fresh search runs, or after one
+/// failed. The list underneath stays usable throughout.
+class _RefreshBanner extends StatelessWidget {
+  const _RefreshBanner({
+    required this.progress,
+    required this.error,
+    required this.stale,
+    required this.onRetry,
+    required this.onDismiss,
+  });
+
+  final SearchProgress? progress;
+  final String error;
+
+  /// Whether the refresh was started because an offer change lies behind
+  /// the shown result, which is worth saying, or by hand, which is not.
+  final bool stale;
+  final VoidCallback onRetry;
+  final VoidCallback onDismiss;
+
+  @override
+  Widget build(BuildContext context) {
+    final colors = context.colors;
+    if (error.isNotEmpty) {
+      return Container(
+        margin: const EdgeInsets.fromLTRB(12, 0, 12, 6),
+        padding: const EdgeInsets.fromLTRB(12, 6, 4, 6),
+        decoration: BoxDecoration(
+          color: colors.error.withValues(alpha: 0.08),
+          borderRadius: BorderRadius.circular(10),
+          border: Border.all(color: colors.error.withValues(alpha: 0.4)),
+        ),
+        child: Row(
+          children: [
+            Expanded(
+              child: Text(
+                'Aktualisierung fehlgeschlagen: $error',
+                style: TextStyle(color: colors.error, fontSize: 13),
+              ),
+            ),
+            TextButton(onPressed: onRetry, child: const Text('Erneut')),
+            IconButton(
+              tooltip: 'Ausblenden',
+              onPressed: onDismiss,
+              icon: const Icon(Icons.close, size: 18),
+            ),
+          ],
+        ),
+      );
+    }
+    final percent = progress?.progress ?? 0;
+    final reason = stale
+        ? 'Neue Angebote seit ${OfferWeek.lastChangeLabel(DateTime.now())}'
+        : 'Angebote werden neu geladen';
+    final detail = [
+      if ((progress?.step ?? '').isNotEmpty) progress!.step,
+      if ((progress?.retailer ?? '').isNotEmpty) progress!.retailer,
+    ].join(' · ');
+    return Container(
+      margin: const EdgeInsets.fromLTRB(12, 0, 12, 6),
+      padding: const EdgeInsets.fromLTRB(12, 8, 12, 8),
+      decoration: BoxDecoration(
+        color: colors.chip,
+        borderRadius: BorderRadius.circular(10),
+      ),
+      child: Column(
+        crossAxisAlignment: CrossAxisAlignment.stretch,
+        children: [
+          Row(
+            children: [
+              Expanded(
+                child: Text(
+                  '$reason · Vergleich wird aktualisiert',
+                  style: const TextStyle(
+                    fontSize: 13,
+                    fontWeight: FontWeight.w600,
+                  ),
+                ),
+              ),
+              Text(
+                '$percent %',
+                style: TextStyle(color: colors.muted, fontSize: 13),
+              ),
+            ],
+          ),
+          const SizedBox(height: 6),
+          ClipRRect(
+            borderRadius: BorderRadius.circular(999),
+            child: LinearProgressIndicator(
+              value: percent <= 0 ? null : percent / 100,
+              minHeight: 5,
+              backgroundColor: colors.panel,
+              valueColor: AlwaysStoppedAnimation(colors.accent),
+            ),
+          ),
+          if (detail.isNotEmpty) ...[
+            const SizedBox(height: 4),
+            Text(
+              detail,
+              style: TextStyle(color: colors.muted, fontSize: 12),
+              overflow: TextOverflow.ellipsis,
+            ),
+          ],
+        ],
       ),
     );
   }

--- a/app/lib/screens/settings_screen.dart
+++ b/app/lib/screens/settings_screen.dart
@@ -186,7 +186,7 @@ class _SettingsScreenState extends State<SettingsScreen> {
           subtitle: const Text(
             'Öffnet beim Start die letzte Suche für die gespeicherte PLZ. '
             'Die Händler werden nur neu abgefragt, wenn seitdem ein '
-            'Angebotswechsel (Montag oder Donnerstag) lag. Eine andere PLZ '
+            'Angebotswechsel lag (Donnerstag, neue Woche ab Sonntag). Eine andere PLZ '
             'gibt es über den Titel der Ergebnisliste.',
           ),
           onChanged: _busy

--- a/app/lib/screens/settings_screen.dart
+++ b/app/lib/screens/settings_screen.dart
@@ -176,6 +176,28 @@ class _SettingsScreenState extends State<SettingsScreen> {
         ),
         const Divider(height: 40),
         const Text(
+          'Start',
+          style: TextStyle(fontSize: 18, fontWeight: FontWeight.bold),
+        ),
+        SwitchListTile(
+          contentPadding: EdgeInsets.zero,
+          value: widget.settings.autoStart,
+          title: const Text('Direkt mit den Angeboten starten'),
+          subtitle: const Text(
+            'Öffnet beim Start die letzte Suche für die gespeicherte PLZ. '
+            'Die Händler werden nur neu abgefragt, wenn seitdem ein '
+            'Angebotswechsel (Montag oder Donnerstag) lag. Eine andere PLZ '
+            'gibt es über den Titel der Ergebnisliste.',
+          ),
+          onChanged: _busy
+              ? null
+              : (value) async {
+                  await widget.settings.setAutoStart(value);
+                  if (mounted) setState(() {});
+                },
+        ),
+        const Divider(height: 40),
+        const Text(
           'Eigener KorbKlar-Server',
           style: TextStyle(fontSize: 18, fontWeight: FontWeight.bold),
         ),

--- a/app/lib/services/offer_week.dart
+++ b/app/lib/services/offer_week.dart
@@ -6,6 +6,10 @@
 /// reason to re-query every source on each start. After one of them it does,
 /// even though nothing about the stored result says so.
 ///
+/// The week starts on Sunday here, not Monday: the server already selects the
+/// coming week on Sundays because most retailers publish it by then, so a
+/// Saturday result is out of date on Sunday morning.
+///
 /// Everything here is local time on purpose: the leaflets follow the calendar
 /// of the shop, and the device of someone comparing German offers is set to
 /// the same one.
@@ -13,7 +17,7 @@ class OfferWeek {
   const OfferWeek._();
 
   /// Weekdays on which offers change, at midnight.
-  static const changeWeekdays = {DateTime.monday, DateTime.thursday};
+  static const changeWeekdays = {DateTime.sunday, DateTime.thursday};
 
   /// Midnight of the most recent change day at or before [now].
   static DateTime lastChange(DateTime now) {
@@ -42,7 +46,7 @@ class OfferWeek {
   /// The German name of the weekday the latest change fell on, for the UI.
   static String lastChangeLabel(DateTime now) =>
       switch (lastChange(now).weekday) {
-        DateTime.monday => 'Montag',
+        DateTime.sunday => 'Sonntag',
         DateTime.thursday => 'Donnerstag',
         _ => 'dieser Woche',
       };

--- a/app/lib/services/offer_week.dart
+++ b/app/lib/services/offer_week.dart
@@ -1,0 +1,49 @@
+/// When retailers change their offers.
+///
+/// German weekly leaflets run Monday to Saturday, and the discounters (ALDI,
+/// Lidl, Netto, PENNY, Kaufland) start a second wave on Thursday. Between
+/// those two moments a comparison does not go out of date, so the app has no
+/// reason to re-query every source on each start. After one of them it does,
+/// even though nothing about the stored result says so.
+///
+/// Everything here is local time on purpose: the leaflets follow the calendar
+/// of the shop, and the device of someone comparing German offers is set to
+/// the same one.
+class OfferWeek {
+  const OfferWeek._();
+
+  /// Weekdays on which offers change, at midnight.
+  static const changeWeekdays = {DateTime.monday, DateTime.thursday};
+
+  /// Midnight of the most recent change day at or before [now].
+  static DateTime lastChange(DateTime now) {
+    var day = DateTime(now.year, now.month, now.day);
+    while (!changeWeekdays.contains(day.weekday)) {
+      // Built from components rather than subtracted as a Duration, so a
+      // DST switch inside the week cannot land this an hour off midnight.
+      day = DateTime(day.year, day.month, day.day - 1);
+    }
+    return day;
+  }
+
+  /// Midnight of the first change day after [now].
+  static DateTime nextChange(DateTime now) {
+    var day = DateTime(now.year, now.month, now.day + 1);
+    while (!changeWeekdays.contains(day.weekday)) {
+      day = DateTime(day.year, day.month, day.day + 1);
+    }
+    return day;
+  }
+
+  /// Whether a comparison made at [searchedAt] predates the latest change.
+  static bool isStale(DateTime searchedAt, {DateTime? now}) =>
+      searchedAt.isBefore(lastChange(now ?? DateTime.now()));
+
+  /// The German name of the weekday the latest change fell on, for the UI.
+  static String lastChangeLabel(DateTime now) =>
+      switch (lastChange(now).weekday) {
+        DateTime.monday => 'Montag',
+        DateTime.thursday => 'Donnerstag',
+        _ => 'dieser Woche',
+      };
+}

--- a/app/lib/services/settings.dart
+++ b/app/lib/services/settings.dart
@@ -2,6 +2,36 @@ import 'package:flutter_secure_storage/flutter_secure_storage.dart';
 import 'package:flutter/services.dart';
 import 'package:shared_preferences/shared_preferences.dart';
 
+import '../api/client.dart';
+
+/// The comparison the app showed last, so the next start can open it again
+/// instead of asking for the postal code and waiting for every retailer.
+///
+/// The result token is the signed link the server issued; it is not a
+/// credential, the same string sits in every result URL the browser shows.
+class LastSearch {
+  const LastSearch({
+    required this.postalCode,
+    required this.retailers,
+    required this.searchId,
+    required this.token,
+    required this.searchedAt,
+  });
+
+  final String postalCode;
+  final List<String> retailers;
+  final String searchId;
+  final String token;
+  final DateTime searchedAt;
+
+  ResultHandle get handle => ResultHandle(searchId: searchId, token: token);
+
+  /// Whether this search covers the same postal code and retailer selection.
+  bool matches(String postalCode, List<String> retailers) =>
+      this.postalCode == postalCode &&
+      this.retailers.join(',') == retailers.join(',');
+}
+
 /// Locally remembered preferences. Nothing here leaves the device except the
 /// server address the user typed themselves.
 class Settings {
@@ -97,6 +127,56 @@ class Settings {
   String get shoppingListEntity => _prefs.getString(_listEntity) ?? '';
   Future<void> setShoppingListEntity(String value) =>
       _prefs.setString(_listEntity, value);
+
+  static const _autoStart = 'auto_start';
+  static const _lastSearchPostalCode = 'last_search_postal_code';
+  static const _lastSearchRetailers = 'last_search_retailers';
+  static const _lastSearchId = 'last_search_id';
+  static const _lastSearchToken = 'last_search_token';
+  static const _lastSearchAt = 'last_search_at';
+
+  /// Open the last comparison straight away on start instead of showing the
+  /// postal-code form. On by default: the postal code rarely changes, and a
+  /// new one is one tap away from the results.
+  bool get autoStart => _prefs.getBool(_autoStart) ?? true;
+  Future<void> setAutoStart(bool value) => _prefs.setBool(_autoStart, value);
+
+  LastSearch? get lastSearch {
+    final searchId = _prefs.getString(_lastSearchId) ?? '';
+    final token = _prefs.getString(_lastSearchToken) ?? '';
+    final searchedAt = DateTime.tryParse(_prefs.getString(_lastSearchAt) ?? '');
+    if (searchId.isEmpty || token.isEmpty || searchedAt == null) return null;
+    return LastSearch(
+      postalCode: _prefs.getString(_lastSearchPostalCode) ?? '',
+      retailers: _prefs.getStringList(_lastSearchRetailers) ?? const [],
+      searchId: searchId,
+      token: token,
+      searchedAt: searchedAt.toLocal(),
+    );
+  }
+
+  Future<void> setLastSearch(LastSearch value) async {
+    await _prefs.setString(_lastSearchPostalCode, value.postalCode);
+    await _prefs.setStringList(_lastSearchRetailers, value.retailers);
+    await _prefs.setString(_lastSearchId, value.searchId);
+    await _prefs.setString(_lastSearchToken, value.token);
+    await _prefs.setString(
+      _lastSearchAt,
+      value.searchedAt.toUtc().toIso8601String(),
+    );
+  }
+
+  Future<void> clearLastSearch() async {
+    for (final key in [
+      _lastSearchPostalCode,
+      _lastSearchRetailers,
+      _lastSearchId,
+      _lastSearchToken,
+      _lastSearchAt,
+    ]) {
+      await _prefs.remove(key);
+    }
+  }
 
   static String normalizeThemeMode(String value) =>
       const {'system', 'light', 'dark'}.contains(value) ? value : 'system';

--- a/app/pubspec.lock
+++ b/app/pubspec.lock
@@ -388,10 +388,10 @@ packages:
     dependency: transitive
     description:
       name: matcher
-      sha256: dc0b7dc7651697ea4ff3e69ef44b0407ea32c487a39fff6a4004fa585e901861
+      sha256: "31bd099b47c10cd1aeb55146a2d46ce0277630ecef3f7dae54ad7873f36696cd"
       url: "https://pub.dev"
     source: hosted
-    version: "0.12.19"
+    version: "0.12.20"
   material_color_utilities:
     dependency: transitive
     description:
@@ -404,10 +404,10 @@ packages:
     dependency: transitive
     description:
       name: meta
-      sha256: "1741988757a65eb6b36abe716829688cf01910bbf91c34354ff7ec1c3de2b349"
+      sha256: "307249ce4ff29d58a18e97f6345f539382eb9c9c29ecda628900f31de0443dd9"
       url: "https://pub.dev"
     source: hosted
-    version: "1.18.0"
+    version: "1.19.0"
   objective_c:
     dependency: transitive
     description:
@@ -641,10 +641,10 @@ packages:
     dependency: transitive
     description:
       name: test_api
-      sha256: "949a932224383300f01be9221c39180316445ecb8e7547f70a41a35bf421fb9e"
+      sha256: "2a122cbe059f8b610d3a5415f42e255b6c17b1f21eee1d960f31080237fb4f11"
       url: "https://pub.dev"
     source: hosted
-    version: "0.7.11"
+    version: "0.7.12"
   typed_data:
     dependency: transitive
     description:
@@ -729,10 +729,10 @@ packages:
     dependency: transitive
     description:
       name: vector_math
-      sha256: d530bd74fea330e6e364cda7a85019c434070188383e1cd8d9777ee586914c5b
+      sha256: f36f9f3be64c6198714492bb455c11056e33e2f85d9a0b676a48301e44fdcf47
       url: "https://pub.dev"
     source: hosted
-    version: "2.2.0"
+    version: "2.4.2"
   vm_service:
     dependency: transitive
     description:

--- a/app/test/offer_week_test.dart
+++ b/app/test/offer_week_test.dart
@@ -1,0 +1,55 @@
+import 'package:flutter_test/flutter_test.dart';
+import 'package:korbklar_app/services/offer_week.dart';
+
+void main() {
+  // 2026-09-02 is a Wednesday.
+  final wednesday = DateTime(2026, 9, 2, 14, 30);
+
+  test('the latest change before a Wednesday is Monday midnight', () {
+    expect(OfferWeek.lastChange(wednesday), DateTime(2026, 8, 31));
+  });
+
+  test('Thursday counts as a change from midnight on', () {
+    expect(
+      OfferWeek.lastChange(DateTime(2026, 9, 3, 0, 0, 1)),
+      DateTime(2026, 9, 3),
+    );
+    expect(
+      OfferWeek.lastChange(DateTime(2026, 9, 6, 23)),
+      DateTime(2026, 9, 3),
+    );
+  });
+
+  test('a search from Tuesday is still fresh on Wednesday', () {
+    expect(OfferWeek.isStale(DateTime(2026, 9, 1, 9), now: wednesday), isFalse);
+  });
+
+  test('a search from Sunday is stale on Wednesday', () {
+    expect(
+      OfferWeek.isStale(DateTime(2026, 8, 30, 18), now: wednesday),
+      isTrue,
+    );
+  });
+
+  test('a search from Wednesday is stale on Thursday morning', () {
+    expect(OfferWeek.isStale(wednesday, now: DateTime(2026, 9, 3, 7)), isTrue);
+  });
+
+  test('the next change after Wednesday is Thursday, after Friday Monday', () {
+    expect(OfferWeek.nextChange(wednesday), DateTime(2026, 9, 3));
+    expect(OfferWeek.nextChange(DateTime(2026, 9, 4)), DateTime(2026, 9, 7));
+  });
+
+  test('the boundary stays at midnight across a DST switch', () {
+    // 2026-10-25 is the Sunday clocks go back in Germany; the Monday before
+    // it must still come out as 00:00, not 01:00 or 23:00.
+    final change = OfferWeek.lastChange(DateTime(2026, 10, 28, 12));
+    expect(change, DateTime(2026, 10, 26));
+    expect(change.hour, 0);
+  });
+
+  test('the label names the weekday of the latest change', () {
+    expect(OfferWeek.lastChangeLabel(wednesday), 'Montag');
+    expect(OfferWeek.lastChangeLabel(DateTime(2026, 9, 5)), 'Donnerstag');
+  });
+}

--- a/app/test/offer_week_test.dart
+++ b/app/test/offer_week_test.dart
@@ -5,8 +5,9 @@ void main() {
   // 2026-09-02 is a Wednesday.
   final wednesday = DateTime(2026, 9, 2, 14, 30);
 
-  test('the latest change before a Wednesday is Monday midnight', () {
-    expect(OfferWeek.lastChange(wednesday), DateTime(2026, 8, 31));
+  test('the latest change before a Wednesday is Sunday midnight', () {
+    // Sunday, not Monday: the server already switches weeks on Sunday.
+    expect(OfferWeek.lastChange(wednesday), DateTime(2026, 8, 30));
   });
 
   test('Thursday counts as a change from midnight on', () {
@@ -15,7 +16,7 @@ void main() {
       DateTime(2026, 9, 3),
     );
     expect(
-      OfferWeek.lastChange(DateTime(2026, 9, 6, 23)),
+      OfferWeek.lastChange(DateTime(2026, 9, 5, 23)),
       DateTime(2026, 9, 3),
     );
   });
@@ -24,10 +25,17 @@ void main() {
     expect(OfferWeek.isStale(DateTime(2026, 9, 1, 9), now: wednesday), isFalse);
   });
 
-  test('a search from Sunday is stale on Wednesday', () {
+  test('a search from Saturday is stale on Sunday', () {
+    expect(
+      OfferWeek.isStale(DateTime(2026, 9, 5, 18), now: DateTime(2026, 9, 6, 8)),
+      isTrue,
+    );
+  });
+
+  test('a search from Sunday is still fresh on Wednesday', () {
     expect(
       OfferWeek.isStale(DateTime(2026, 8, 30, 18), now: wednesday),
-      isTrue,
+      isFalse,
     );
   });
 
@@ -35,21 +43,26 @@ void main() {
     expect(OfferWeek.isStale(wednesday, now: DateTime(2026, 9, 3, 7)), isTrue);
   });
 
-  test('the next change after Wednesday is Thursday, after Friday Monday', () {
+  test('the next change after Wednesday is Thursday, after Friday Sunday', () {
     expect(OfferWeek.nextChange(wednesday), DateTime(2026, 9, 3));
-    expect(OfferWeek.nextChange(DateTime(2026, 9, 4)), DateTime(2026, 9, 7));
+    expect(OfferWeek.nextChange(DateTime(2026, 9, 4)), DateTime(2026, 9, 6));
   });
 
   test('the boundary stays at midnight across a DST switch', () {
-    // 2026-10-25 is the Sunday clocks go back in Germany; the Monday before
-    // it must still come out as 00:00, not 01:00 or 23:00.
-    final change = OfferWeek.lastChange(DateTime(2026, 10, 28, 12));
-    expect(change, DateTime(2026, 10, 26));
-    expect(change.hour, 0);
+    // Clocks go back on Sunday 2026-10-25 at 03:00.
+    expect(
+      OfferWeek.nextChange(DateTime(2026, 10, 23, 12)),
+      DateTime(2026, 10, 25),
+    );
+    expect(
+      OfferWeek.lastChange(DateTime(2026, 10, 26, 12)),
+      DateTime(2026, 10, 25),
+    );
+    expect(OfferWeek.lastChange(DateTime(2026, 10, 26, 12)).hour, 0);
   });
 
   test('the label names the weekday of the latest change', () {
-    expect(OfferWeek.lastChangeLabel(wednesday), 'Montag');
-    expect(OfferWeek.lastChangeLabel(DateTime(2026, 9, 5)), 'Donnerstag');
+    expect(OfferWeek.lastChangeLabel(wednesday), 'Sonntag');
+    expect(OfferWeek.lastChangeLabel(DateTime(2026, 9, 4)), 'Donnerstag');
   });
 }

--- a/app/test/settings_test.dart
+++ b/app/test/settings_test.dart
@@ -16,4 +16,50 @@ void main() {
     expect(reloaded.selectedRetailers, ['REWE', 'dm']);
     expect(reloaded.hasSelectedRetailers, isTrue);
   });
+
+  test('starting straight into the results is the default', () async {
+    SharedPreferences.setMockInitialValues({});
+    final settings = await Settings.load();
+    expect(settings.autoStart, isTrue);
+    await settings.setAutoStart(false);
+    expect((await Settings.load()).autoStart, isFalse);
+  });
+
+  test(
+    'the last search survives a restart and knows what it covered',
+    () async {
+      SharedPreferences.setMockInitialValues({});
+      final settings = await Settings.load();
+      expect(settings.lastSearch, isNull);
+
+      final searchedAt = DateTime(2026, 9, 1, 9, 30);
+      await settings.setLastSearch(
+        LastSearch(
+          postalCode: '26188',
+          retailers: const ['REWE', 'Lidl'],
+          searchId: 'search-1',
+          token: 'signed',
+          searchedAt: searchedAt,
+        ),
+      );
+
+      final last = (await Settings.load()).lastSearch;
+      expect(last, isNotNull);
+      expect(last!.handle.searchId, 'search-1');
+      expect(last.handle.token, 'signed');
+      expect(last.searchedAt, searchedAt);
+      expect(last.matches('26188', const ['REWE', 'Lidl']), isTrue);
+      // A different postal code or retailer selection is a different search.
+      expect(last.matches('26123', const ['REWE', 'Lidl']), isFalse);
+      expect(last.matches('26188', const []), isFalse);
+
+      await settings.clearLastSearch();
+      expect((await Settings.load()).lastSearch, isNull);
+    },
+  );
+
+  test('an incomplete stored search is ignored rather than opened', () async {
+    SharedPreferences.setMockInitialValues({'last_search_id': 'search-1'});
+    expect((await Settings.load()).lastSearch, isNull);
+  });
 }


### PR DESCRIPTION
## Why

Most people compare offers for one postal code, week after week. Typing it and pressing the button every time is friction the app can remove.

## What

- With a saved postal code and a connected server the app opens straight into the last result.
- Retailers are queried again only when an offer change (Thursday, and Sunday for the new week, matching the server's `offer_reference_date`; local time; `app/lib/services/offer_week.dart`) lies between that search and now. The old result stays readable while the new one loads and is swapped in on completion.
- The postal-code title leads back to the search form, the refresh icon starts a new search by hand, and the switch **Direkt mit den Angeboten starten** under Settings (on by default) turns the behaviour off.

## Tests

`app/test/offer_week_test.dart` and new cases in `app/test/settings_test.dart`. `flutter analyze` clean; `flutter test --exclude-tags golden,live` passes. The golden suite is opt-in and platform dependent; if a golden moves because of the new title it should be re-recorded on the reference platform.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01XqnkcdEQt1ZYjcBNVS1DQ8
