### PR TITLE
app: Angebote als Haushaltsartikel nach KitchenOwl, Kategorie je Markt

### DIFF
--- a/app/README.md
+++ b/app/README.md
@@ -63,22 +63,35 @@ search by hand.
 
 ## Shopping list
 
-Every offer carries an **Auf KitchenOwl** button that files it straight into
-the list named in the bar above the results, the same one-tap flow the browser
-uses. The button then reads "in <list>" so a filed offer stays recognisable
-while scrolling. Checking the article off in KitchenOwl clears that mark
-again on the next load, since KitchenOwl removes a checked entry from the
-list. The chosen list is remembered on the device.
+Every offer carries a **Zur Einkaufsliste** button that adds it to the
+persistent local shopping list. That list opens from the basket icon and can
+be exported through the clipboard without a server connection.
 
-The user can connect KitchenOwl directly in **Settings → Connections**. The
-long-lived token stays on the device and is sent only to the configured HTTPS
-KitchenOwl host. It is never forwarded to the KorbKlar server. If the server
-provides its own compatible KitchenOwl endpoint, the client can still use that
-as a fallback.
+With a KitchenOwl connected in **Settings → Connections**, each offer gets a
+second button, **Auf KitchenOwl**, that files it straight into the list named
+in the bar above the results. The button then reads "in <article>" so a filed
+offer stays recognisable while scrolling. Checking the article off in
+KitchenOwl clears that mark again on the next load, since KitchenOwl removes
+a checked entry from the list. The chosen list is remembered on the device.
+The switch **Nur KitchenOwl verwenden** hides the local list altogether, so
+the offer card keeps a single button; it falls back to the local list while
+KitchenOwl is unreachable.
 
-Where no KitchenOwl list is configured, offers go to the persistent local
-shopping list. It can be opened from the basket icon and exported through the
-clipboard without a server connection.
+What KitchenOwl receives is an article, not a headline. The app reads the
+household's own articles and files the offer on the one that matches, so
+"JA! Weizenbrötchen 6 Stück" lands on the existing "Brötchen" with its icon
+(`services/kitchenowl_articles.dart`, the same rules the browser side once
+used: whole-word matching, head noun last, longest match wins). Where none
+matches, the offer name is shortened to the staple: private-label shouting,
+pack sizes and "aus der Region" go. The note under the article carries the
+offer wording, the price and the validity, nothing else. The article is filed
+under a category named after the shop with a colour dot, "🔴 REWE", so the
+list sorts by store; missing categories are created.
+
+The long-lived token stays on the device and is sent only to the configured
+HTTPS KitchenOwl host. It is never forwarded to the KorbKlar server. If the
+server provides its own compatible KitchenOwl endpoint, the client can still
+use that as a fallback.
 
 ## Toolchain
 

--- a/app/lib/api/kitchenowl_client.dart
+++ b/app/lib/api/kitchenowl_client.dart
@@ -3,6 +3,7 @@ import 'dart:convert';
 
 import 'package:http/http.dart' as http;
 
+import '../services/kitchenowl_articles.dart';
 import 'models.dart';
 
 class KitchenOwlException implements Exception {
@@ -14,6 +15,11 @@ class KitchenOwlException implements Exception {
 
 /// Direct optional connection to a user-owned KitchenOwl instance. The token
 /// is supplied from Android's encrypted storage and never sent to KorbKlar.
+///
+/// Besides the list of targets, the client reads what the household already
+/// keeps so an offer lands on the existing article ("Brötchen" with its icon)
+/// rather than beside it, and files the article under a category named after
+/// the retailer so the list sorts by shop.
 class KitchenOwlClient {
   KitchenOwlClient({
     required String baseUrl,
@@ -27,6 +33,11 @@ class KitchenOwlClient {
   final http.Client _http;
   static const _timeout = Duration(seconds: 20);
 
+  /// What the household keeps, per household id. Read once per screen; a
+  /// stale entry costs a near duplicate at worst, never a lost offer.
+  final _catalogues = <String, List<String>>{};
+  final _categories = <String, Map<String, int>>{};
+
   bool get configured => baseUrl.isNotEmpty && token.isNotEmpty;
   bool get secure => Uri.tryParse(baseUrl)?.scheme == 'https';
   Map<String, String> get _headers => {
@@ -36,6 +47,14 @@ class KitchenOwlClient {
   };
 
   Uri _uri(String path) => Uri.parse('$baseUrl$path');
+
+  void _requireSecure() {
+    if (!secure) {
+      throw KitchenOwlException(
+        'KitchenOwl-Tokens dürfen nur über HTTPS übertragen werden.',
+      );
+    }
+  }
 
   dynamic _decode(http.Response response) {
     if (response.statusCode == 401 || response.statusCode == 403) {
@@ -50,43 +69,20 @@ class KitchenOwlClient {
     return jsonDecode(utf8.decode(response.bodyBytes));
   }
 
-  Future<List<ShoppingListTarget>> targets() async {
-    if (!configured) return const [];
-    if (!secure) {
-      throw KitchenOwlException(
-        'KitchenOwl-Tokens dürfen nur über HTTPS übertragen werden.',
-      );
-    }
-    try {
-      final households = _decode(
+  Future<dynamic> _get(String path) async =>
+      _decode(await _http.get(_uri(path), headers: _headers).timeout(_timeout));
+
+  Future<dynamic> _post(String path, Map<String, Object?> payload) async =>
+      _decode(
         await _http
-            .get(_uri('/api/household'), headers: _headers)
+            .post(_uri(path), headers: _headers, body: jsonEncode(payload))
             .timeout(_timeout),
       );
-      final result = <ShoppingListTarget>[];
-      for (final household in households is List ? households : const []) {
-        if (household is! Map || household['id'] == null) continue;
-        final householdName = '${household['name'] ?? ''}'.trim();
-        final lists = _decode(
-          await _http
-              .get(
-                _uri('/api/household/${household['id']}/shoppinglist'),
-                headers: _headers,
-              )
-              .timeout(_timeout),
-        );
-        for (final list in lists is List ? lists : const []) {
-          if (list is! Map || list['id'] == null) continue;
-          final name = '${list['name'] ?? 'Einkauf'}'.trim();
-          result.add(
-            ShoppingListTarget(
-              entityId: '${list['id']}',
-              label: householdName.isEmpty ? name : '$householdName · $name',
-            ),
-          );
-        }
-      }
-      return result;
+
+  Future<T> _call<T>(Future<T> Function() action) async {
+    _requireSecure();
+    try {
+      return await action();
     } on KitchenOwlException {
       rethrow;
     } on Object catch (error) {
@@ -94,42 +90,133 @@ class KitchenOwlClient {
     }
   }
 
-  Future<String> addOffer(String listId, Offer offer) async {
+  static List<Map> _entries(Object? payload) =>
+      payload is List ? payload.whereType<Map>().toList() : const [];
+
+  static String _name(Map entry) => '${entry['name'] ?? ''}'.trim();
+
+  /// Every shopping list the token can reach, labelled with its household.
+  Future<List<ShoppingListTarget>> targets() async {
+    if (!configured) return const [];
+    return _call(() async {
+      final result = <ShoppingListTarget>[];
+      for (final household in _entries(await _get('/api/household'))) {
+        if (household['id'] == null) continue;
+        final householdId = '${household['id']}';
+        final householdName = _name(household);
+        final lists = await _get('/api/household/$householdId/shoppinglist');
+        for (final list in _entries(lists)) {
+          if (list['id'] == null) continue;
+          final name = _name(list).isEmpty ? 'Einkauf' : _name(list);
+          result.add(
+            ShoppingListTarget(
+              entityId: '${list['id']}',
+              label: householdName.isEmpty ? name : '$householdName · $name',
+              householdId: householdId,
+            ),
+          );
+        }
+      }
+      return result;
+    });
+  }
+
+  /// Article names the household already keeps.
+  Future<List<String>> catalogue(String householdId) async {
+    final cached = _catalogues[householdId];
+    if (cached != null) return cached;
+    final names = [
+      for (final item in _entries(
+        await _get('/api/household/$householdId/item'),
+      ))
+        if (_name(item).isNotEmpty) _name(item),
+    ];
+    _catalogues[householdId] = names;
+    return names;
+  }
+
+  /// The category id for this name, created when the household lacks it.
+  Future<int?> _categoryId(String householdId, String name) async {
+    var known = _categories[householdId];
+    if (known == null) {
+      known = {
+        for (final entry in _entries(
+          await _get('/api/household/$householdId/category'),
+        ))
+          if (entry['id'] is int && _name(entry).isNotEmpty)
+            _name(entry).toLowerCase(): entry['id'] as int,
+      };
+      _categories[householdId] = known;
+    }
+    final existing = known[name.toLowerCase()];
+    if (existing != null) return existing;
+    final created = await _post('/api/household/$householdId/category', {
+      'name': name,
+    });
+    if (created is! Map || created['id'] is! int) return null;
+    known[name.toLowerCase()] = created['id'] as int;
+    return created['id'] as int;
+  }
+
+  /// Article names currently on the list.
+  ///
+  /// KitchenOwl removes an entry when it is checked off, so this is what
+  /// tells the app that an offer it filed earlier is no longer pending.
+  Future<Set<String>> entries(String listId) => _call(() async {
+    final names = <String>{};
+    for (final entry in _entries(
+      await _get('/api/shoppinglist/$listId/items'),
+    )) {
+      var name = _name(entry);
+      if (name.isEmpty && entry['item'] is Map) name = _name(entry['item']);
+      if (name.isNotEmpty) names.add(name);
+    }
+    return names;
+  });
+
+  /// Files one offer and returns the article name KitchenOwl stored it under.
+  ///
+  /// With [householdId] the offer lands on a matching article the household
+  /// already keeps and is filed under the retailer's category; without it
+  /// the shortened offer name is used and no category is set.
+  Future<String> addOffer(
+    String listId,
+    Offer offer, {
+    String householdId = '',
+  }) async {
     if (!RegExp(r'^\d+$').hasMatch(listId)) {
       throw KitchenOwlException('Ungültige KitchenOwl-Listen-ID.');
     }
-    if (!secure) {
-      throw KitchenOwlException(
-        'KitchenOwl-Tokens dürfen nur über HTTPS übertragen werden.',
+    return _call(() async {
+      final catalogue = householdId.isEmpty
+          ? const <String>[]
+          : await this.catalogue(householdId);
+      final article = articleFor(offer, catalogue);
+      final note = noteFor(offer, article);
+      final created = await _post(
+        '/api/shoppinglist/$listId/add-item-by-name',
+        {'name': article, if (note.isNotEmpty) 'description': note},
       );
-    }
-    final price = offer.effectivePriceText.isNotEmpty
-        ? offer.effectivePriceText
-        : offer.regularPriceText;
-    final description = [
-      offer.retailerText,
-      price,
-      offer.pack,
-      offer.validity,
-    ].where((item) => item.isNotEmpty).join(' · ');
-    final payload = <String, String>{'name': offer.product};
-    if (description.isNotEmpty) payload['description'] = description;
-    try {
-      _decode(
-        await _http
-            .post(
-              _uri('/api/shoppinglist/$listId/add-item-by-name'),
-              headers: _headers,
-              body: jsonEncode(payload),
-            )
-            .timeout(_timeout),
-      );
-      return offer.product;
-    } on KitchenOwlException {
-      rethrow;
-    } on Object catch (error) {
-      throw KitchenOwlException('KitchenOwl ist nicht erreichbar: $error');
-    }
+      if (!catalogue.contains(article)) _catalogues[householdId]?.add(article);
+
+      final category = retailerCategory(offer.retailer);
+      if (householdId.isNotEmpty &&
+          category.isNotEmpty &&
+          created is Map &&
+          created['id'] != null) {
+        try {
+          final categoryId = await _categoryId(householdId, category);
+          if (categoryId != null) {
+            await _post('/api/item/${created['id']}', {
+              'category': {'id': categoryId},
+            });
+          }
+        } on Object {
+          // The article is on the list; filing it under the shop is a nicety.
+        }
+      }
+      return article;
+    });
   }
 
   void close() => _http.close();

--- a/app/lib/api/models.dart
+++ b/app/lib/api/models.dart
@@ -348,9 +348,14 @@ class SearchProgress {
   bool get isFailed => status == 'failed';
 }
 
-/// A shopping list exposed by the server's KitchenOwl integration.
+/// A shopping list exposed by the server's KitchenOwl integration or read
+/// from a KitchenOwl the app talks to directly.
 class ShoppingListTarget {
-  const ShoppingListTarget({required this.entityId, required this.label});
+  const ShoppingListTarget({
+    required this.entityId,
+    required this.label,
+    this.householdId = '',
+  });
 
   factory ShoppingListTarget.fromJson(Map<String, dynamic> json) =>
       ShoppingListTarget(
@@ -360,6 +365,10 @@ class ShoppingListTarget {
 
   final String entityId;
   final String label;
+
+  /// The KitchenOwl household the list belongs to. Only the direct
+  /// connection knows it; it is what articles and categories hang on.
+  final String householdId;
 }
 
 /// What the server reports about its shopping-list integration.

--- a/app/lib/screens/home_screen.dart
+++ b/app/lib/screens/home_screen.dart
@@ -611,9 +611,10 @@ class _HomeScreenState extends State<HomeScreen> with WidgetsBindingObserver {
                     child: Row(
                       mainAxisSize: MainAxisSize.min,
                       children: [
-                        LocalShoppingListButton(
-                          store: widget.localShoppingList,
-                        ),
+                        if (!widget.settings.kitchenOwlOnly)
+                          LocalShoppingListButton(
+                            store: widget.localShoppingList,
+                          ),
                         IconButton(
                           tooltip: 'Verbindungen und Einstellungen',
                           onPressed: _busy ? null : _openSettings,

--- a/app/lib/screens/results_screen.dart
+++ b/app/lib/screens/results_screen.dart
@@ -357,17 +357,31 @@ class _ResultsScreenState extends State<ResultsScreen> {
   /// Checking an entry off removes it there, so the app must not keep
   /// claiming it is still on the list.
   Future<void> _reconcileFiled() async {
-    if (_listId.isEmpty) return;
+    if (_listId.isEmpty || _filed.isEmpty) return;
     try {
-      final pending = await widget.client.listEntries(_handle, _listId);
+      final direct = _directKitchenOwl;
+      final pending = direct != null
+          ? await direct.entries(_listId)
+          : await widget.client.listEntries(_handle, _listId);
       if (!mounted) return;
       setState(() {
         _filed.removeWhere((_, article) => !pending.contains(article));
       });
     } on KorbKlarException {
       // Leaving the marks as they are beats guessing they are gone.
+    } on KitchenOwlException {
+      // Same here.
     }
   }
+
+  bool get _kitchenOwlAvailable =>
+      _shoppingList.configured && _shoppingList.targets.isNotEmpty;
+
+  /// Whether the local list is offered at all. It goes away only when the
+  /// user chose KitchenOwl alone and that KitchenOwl is actually reachable,
+  /// so an offer can always go somewhere.
+  bool get _localListShown =>
+      !widget.settings.kitchenOwlOnly || !_kitchenOwlAvailable;
 
   void _onSearchChanged(String _) {
     _debounce?.cancel();
@@ -387,6 +401,94 @@ class _ResultsScreenState extends State<ResultsScreen> {
     } finally {
       if (mounted) setState(() => _sending.remove(offer.key));
     }
+  }
+
+  /// Files one offer in the selected KitchenOwl list.
+  ///
+  /// No collecting step: a tap is the whole interaction. The article lands
+  /// on what the household already keeps where one matches, and under a
+  /// category named after the shop; see `kitchenowl_articles.dart`.
+  Future<void> _addToKitchenOwl(Offer offer) async {
+    final entity = _listId.isNotEmpty ? _listId : await _resolveEntity();
+    if (entity == null || entity.isEmpty) return;
+    final target = _shoppingList.targets.firstWhere(
+      (target) => target.entityId == entity,
+      orElse: () => const ShoppingListTarget(entityId: '', label: 'KitchenOwl'),
+    );
+    setState(() => _sending.add(offer.key));
+    try {
+      final direct = _directKitchenOwl;
+      final added = direct != null
+          ? [
+              await direct.addOffer(
+                entity,
+                offer,
+                householdId: target.householdId,
+              ),
+            ]
+          : await widget.client.addToShoppingList(
+              _handle,
+              entityId: entity,
+              offers: [offer],
+            );
+      if (!mounted) return;
+      final article = added.isNotEmpty ? added.first : offer.product;
+      setState(() => _filed[offer.key] = article);
+      _toast('„$article“ liegt in „${target.label}“.');
+    } on Object catch (exception) {
+      final message = exception is KorbKlarException
+          ? exception.message
+          : exception is KitchenOwlException
+          ? exception.message
+          : '$exception';
+      _toast(message);
+    } finally {
+      if (mounted) setState(() => _sending.remove(offer.key));
+    }
+  }
+
+  Future<String?> _resolveEntity() async {
+    final targets = _shoppingList.targets;
+    if (targets.isEmpty) return null;
+
+    final remembered = widget.settings.shoppingListEntity;
+    final known = targets.map((target) => target.entityId).toSet();
+    if (remembered.isNotEmpty && known.contains(remembered)) return remembered;
+    if (known.contains(_shoppingList.defaultEntity)) {
+      return _shoppingList.defaultEntity;
+    }
+    if (targets.length == 1) return targets.first.entityId;
+
+    final chosen = await showModalBottomSheet<String>(
+      context: context,
+      backgroundColor: context.colors.panel,
+      builder: (sheetContext) => SafeArea(
+        child: Column(
+          mainAxisSize: MainAxisSize.min,
+          children: [
+            const Padding(
+              padding: EdgeInsets.fromLTRB(20, 18, 20, 6),
+              child: Text(
+                'Ziel-Liste wählen',
+                style: TextStyle(fontSize: 17, fontWeight: FontWeight.w700),
+              ),
+            ),
+            for (final target in targets)
+              ListTile(
+                leading: const Icon(Icons.checklist),
+                title: Text(target.label),
+                onTap: () => Navigator.pop(sheetContext, target.entityId),
+              ),
+            const SizedBox(height: 8),
+          ],
+        ),
+      ),
+    );
+    if (chosen != null) {
+      await widget.settings.setShoppingListEntity(chosen);
+      if (mounted) setState(() => _listId = chosen);
+    }
+    return chosen;
   }
 
   void _toast(String message) {
@@ -505,6 +607,9 @@ class _ResultsScreenState extends State<ResultsScreen> {
       appBar: AppBar(
         backgroundColor: colors.bg,
         surfaceTintColor: Colors.transparent,
+        // Up to five actions sit on the right; on a narrow phone the title
+        // gets whatever is left, so it must shrink instead of overflowing.
+        titleSpacing: 0,
         // The title doubles as the way to a different postal code: with the
         // app opening straight into the results, this is where a user looks.
         title: Tooltip(
@@ -517,9 +622,13 @@ class _ResultsScreenState extends State<ResultsScreen> {
               child: Row(
                 mainAxisSize: MainAxisSize.min,
                 children: [
-                  Text(
-                    page == null ? 'Angebote' : 'PLZ ${page.postalCode}',
-                    style: const TextStyle(fontWeight: FontWeight.w700),
+                  Flexible(
+                    child: Text(
+                      page == null ? 'Angebote' : 'PLZ ${page.postalCode}',
+                      maxLines: 1,
+                      overflow: TextOverflow.ellipsis,
+                      style: const TextStyle(fontWeight: FontWeight.w700),
+                    ),
                   ),
                   const SizedBox(width: 6),
                   Icon(
@@ -534,11 +643,17 @@ class _ResultsScreenState extends State<ResultsScreen> {
         ),
         actions: [
           if (_offline)
-            const Padding(
-              padding: EdgeInsets.symmetric(horizontal: 8),
-              child: Center(child: Chip(label: Text('Offline'))),
+            // An icon, not a chip: a chip plus four buttons left the title
+            // no room on a phone.
+            Tooltip(
+              message: 'Offline: gespeicherte Daten',
+              child: Padding(
+                padding: const EdgeInsets.symmetric(horizontal: 6),
+                child: Icon(Icons.cloud_off_outlined, color: colors.muted),
+              ),
             ),
-          LocalShoppingListButton(store: widget.localShoppingList),
+          if (_localListShown)
+            LocalShoppingListButton(store: widget.localShoppingList),
           IconButton(
             tooltip: _offline
                 ? 'Gespeicherte Ergebnisse neu lesen'
@@ -780,11 +895,15 @@ class _ResultsScreenState extends State<ResultsScreen> {
           imageUrl: widget.client.imageUrl(offer.imageUrl),
           imageHeaders: widget.client.imageHeaders,
           showRetailer: _retailer.isEmpty,
-          // Adding from an offer card always targets the app-local list.
-          // Remote KitchenOwl state must not disable or relabel this action.
-          filedIn: null,
+          filedIn: _filed[offer.key],
           sending: _sending.contains(offer.key),
-          onAddToList: () => _addToList(offer),
+          // The local list is its own button and never relabelled by
+          // KitchenOwl state; it only disappears when the user asked for
+          // KitchenOwl alone.
+          onAddToList: _localListShown ? () => _addToList(offer) : null,
+          onAddToKitchenOwl: _kitchenOwlAvailable
+              ? () => _addToKitchenOwl(offer)
+              : null,
           onOpenSource: () => launchUrl(
             Uri.parse(offer.sourceUrl),
             mode: LaunchMode.externalApplication,

--- a/app/lib/screens/settings_screen.dart
+++ b/app/lib/screens/settings_screen.dart
@@ -116,6 +116,8 @@ class _SettingsScreenState extends State<SettingsScreen> {
     if (url.isEmpty && token.isEmpty) {
       await widget.settings.setKitchenOwlUrl('');
       await widget.settings.setKitchenOwlToken('');
+      // Without a KitchenOwl the local list is the only list there is.
+      await widget.settings.setKitchenOwlOnly(false);
       return _show('Direkte KitchenOwl-Verbindung entfernt.');
     }
     if (Uri.tryParse(url)?.scheme != 'https') {
@@ -286,6 +288,32 @@ class _SettingsScreenState extends State<SettingsScreen> {
         FilledButton(
           onPressed: _busy ? null : _saveKitchenOwl,
           child: const Text('KitchenOwl prüfen und speichern'),
+        ),
+        const SizedBox(height: 8),
+        const Text(
+          'Angebote landen auf dem Artikel, den dein Haushalt schon kennt '
+          '(„JA! Weizenbrötchen“ wird zu „Brötchen“ samt Symbol); die Notiz '
+          'nennt Angebot, Preis und Gültigkeit. Jeder Markt bekommt eine '
+          'eigene Kategorie mit Farbpunkt, damit sich die Liste nach Laden '
+          'sortieren lässt.',
+          style: TextStyle(fontSize: 12),
+        ),
+        SwitchListTile(
+          contentPadding: EdgeInsets.zero,
+          value: widget.settings.kitchenOwlOnly,
+          title: const Text('Nur KitchenOwl verwenden'),
+          subtitle: Text(
+            widget.settings.hasKitchenOwl
+                ? 'Blendet die lokale Einkaufsliste aus. Jedes Angebot geht '
+                      'direkt auf die KitchenOwl-Liste.'
+                : 'Erst verfügbar, wenn KitchenOwl verbunden ist.',
+          ),
+          onChanged: _busy || !widget.settings.hasKitchenOwl
+              ? null
+              : (value) async {
+                  await widget.settings.setKitchenOwlOnly(value);
+                  if (mounted) setState(() {});
+                },
         ),
         if (_message.isNotEmpty)
           Padding(

--- a/app/lib/services/kitchenowl_articles.dart
+++ b/app/lib/services/kitchenowl_articles.dart
@@ -1,0 +1,229 @@
+/// How an offer becomes a KitchenOwl article.
+///
+/// KitchenOwl keeps a household's staples as articles with icons: "Brot",
+/// "Wasser", "Butter". A leaflet calls the same thing "JA! Weizenbrötchen
+/// 6 Stück". Filing the offer under the household's own article keeps the
+/// icon and lets next week's differently worded offer land on the same
+/// entry; the leaflet wording moves into the note.
+///
+/// Pure Dart, so it can be tested without a device or a KitchenOwl.
+library;
+
+import '../api/models.dart';
+
+/// Below this an existing article says too little to be worth matching:
+/// "Ei" would swallow half a catalogue.
+const _minMatchLength = 4;
+
+/// A household staple is named in a word or three. Anything longer in the
+/// catalogue is an offer headline, most likely one an earlier version filed
+/// there, and matching against it would keep every later offer for the
+/// same product away from the real article.
+const _maxArticleWords = 3;
+
+const _trailingWords = {
+  'aus', 'mit', 'ohne', 'in', 'im', 'von', 'vom', 'der', 'die', 'das', //
+  'und', 'oder', 'je', 'pro', 'à', 'a', 'zum', 'zur', 'nach', 'verschiedene',
+  'versch', 'sowie', 'auch', 'z', 'b',
+};
+
+const _unit = r'g|kg|mg|ml|cl|l|stk|stück|st|x|er';
+final _packWord = RegExp(
+  '^([0-9]+([.,][0-9]+)?\\s*($_unit)?|$_unit|packung|beutel|dose|schale)[.,]?\$',
+  caseSensitive: false,
+);
+
+final _letter = RegExp(r'\p{L}', unicode: true);
+
+const maxArticleLength = 200;
+const maxNoteLength = 300;
+
+String _clean(String value) => value.replaceAll(RegExp(r'\s+'), ' ').trim();
+
+String _truncate(String value, int limit) {
+  final text = _clean(value);
+  if (text.length <= limit) return text;
+  return '${text.substring(0, limit - 1).trimRight()}…';
+}
+
+/// Whether a word reads as a brand or marketing line rather than a product.
+///
+/// Leaflets shout their private labels: "GUT&GÜNSTIG", "JA!", "REWE BESTE
+/// WAHL". Three letters keep "H-Milch" and unit letters out of this; a
+/// shouted word with an exclamation mark is a label however short.
+bool _isBrandToken(String token) {
+  final letters = _letter.allMatches(token).length;
+  final shouted = token == token.toUpperCase() && token != token.toLowerCase();
+  return shouted && (letters >= 3 || (letters >= 2 && token.endsWith('!')));
+}
+
+/// Returns the staple an offer is about, without the leaflet wording.
+///
+/// "GUT&GÜNSTIG Weizenbrötchen / Schrippen" is a household's "Weizenbrötchen".
+/// The full offer wording is not lost: it goes into the note.
+String shortenOfferName(String product) {
+  var text = _clean(product);
+  if (text.isEmpty) return '';
+  // An alternative spelling after a slash describes the same product.
+  final head = text.split('/').first.trim();
+  if (head.length >= _minMatchLength) text = head;
+  var words = text.split(' ').where((word) => word.isNotEmpty).toList();
+  // "Rinderhackfleisch aus der Region" is bought as Rinderhackfleisch; what
+  // follows such a word qualifies the offer, not the product.
+  for (var index = 1; index < words.length; index++) {
+    final word = words[index].toLowerCase().replaceAll(
+      RegExp(r'^[,.]+|[,.]+$'),
+      '',
+    );
+    if (_trailingWords.contains(word)) {
+      words = words.sublist(0, index);
+      break;
+    }
+  }
+  var kept = words.where((word) => !_isBrandToken(word)).toList();
+  if (kept.isEmpty) kept = words;
+  // A pack size belongs in the note, not in the article name.
+  while (kept.length > 1 && _packWord.hasMatch(kept.last)) {
+    kept.removeLast();
+  }
+  // German puts the head noun last, so when trimming, the tail is the part
+  // that says what the product is.
+  final tail = kept.length > _maxArticleWords
+      ? kept.sublist(kept.length - _maxArticleWords)
+      : kept;
+  return tail.join(' ');
+}
+
+/// Reduces a name to comparable words.
+List<String> _fold(String value) => _clean(value)
+    .toLowerCase()
+    .replaceAll(RegExp(r'[^0-9a-zäöüß]+'), ' ')
+    .trim()
+    .split(' ')
+    .where((word) => word.isNotEmpty)
+    .toList();
+
+/// Whether a catalogue entry is a leaflet headline instead of a staple.
+bool _isOfferHeadline(String name) {
+  final words = _clean(name).split(' ');
+  return words.length > _maxArticleWords ||
+      (words.length > 1 && words.any(_isBrandToken));
+}
+
+/// Whether the article's words appear in the offer, compounds included.
+///
+/// German puts the head noun last, so an article named "Brötchen" is what
+/// "Weizenbrötchen" is. Only the final word may match as a suffix; matching
+/// the front would turn "Buttermilch" into butter.
+bool _containsSequence(List<String> words, List<String> parts) {
+  if (parts.isEmpty) return false;
+  final last = parts.length - 1;
+  for (var start = 0; start + last < words.length; start++) {
+    var matches = true;
+    for (var offset = 0; offset < last; offset++) {
+      if (words[start + offset] != parts[offset]) {
+        matches = false;
+        break;
+      }
+    }
+    if (!matches) continue;
+    final candidate = words[start + last];
+    if (candidate == parts[last] || candidate.endsWith(parts[last])) {
+      return true;
+    }
+  }
+  return false;
+}
+
+/// Returns the household's own article name for this offer, or '' if none.
+///
+/// An offer is called "GUT&GÜNSTIG Weizenbrötchen / Schrippen" while the
+/// household keeps a plain "Brötchen". Matching on whole words lets the offer
+/// land on the article that already exists instead of creating a near
+/// duplicate, and the longest match wins so "Bio Butter" beats "Butter".
+String matchExistingItem(String product, Iterable<String> catalogue) {
+  final words = _fold(product);
+  var best = '';
+  var bestLength = 0;
+  for (final name in catalogue) {
+    if (_isOfferHeadline(name)) continue;
+    final parts = _fold(name);
+    final folded = parts.join(' ');
+    if (folded.length < _minMatchLength || folded.length <= bestLength) {
+      continue;
+    }
+    if (_containsSequence(words, parts)) {
+      best = name;
+      bestLength = folded.length;
+    }
+  }
+  return best;
+}
+
+/// The article an offer is filed under: the household's own article when
+/// one matches, otherwise the shortened offer name.
+String articleFor(Offer offer, Iterable<String> catalogue) {
+  final matched = matchExistingItem(offer.product, catalogue);
+  if (matched.isNotEmpty) return matched;
+  final short = _truncate(shortenOfferName(offer.product), maxArticleLength);
+  if (short.isNotEmpty) return short;
+  final retailer = _clean(offer.retailerText);
+  return retailer.isEmpty ? 'Angebot' : 'Angebot $retailer';
+}
+
+/// The note shown underneath the article: offer name, price, validity.
+///
+/// The offer name only appears when the article is called something else,
+/// otherwise it would stand there twice. Pack size and unit price are left
+/// out on purpose: the note is read in the shop, where what matters is
+/// which offer this is, what it costs and until when.
+String noteFor(Offer offer, String article) {
+  final price = offer.effectivePriceText.isNotEmpty
+      ? offer.effectivePriceText
+      : offer.regularPriceText;
+  final product = _clean(offer.product);
+  final parts = [
+    if (product != _clean(article)) product,
+    if (price.isNotEmpty) price,
+    if (offer.validity.isNotEmpty) offer.validity,
+  ];
+  return _truncate(parts.join(' · '), maxNoteLength);
+}
+
+/// KitchenOwl categories carry a name and nothing else, so the icon can only
+/// be an emoji in front of it. The colours follow the shops' logos, so a list
+/// sorted by category reads like a row of storefronts.
+const _retailerIcons = {
+  'aldi nord': '🔵',
+  'aldi süd': '🔵',
+  'aldi': '🔵',
+  'lidl': '🟡',
+  'rewe': '🔴',
+  'edeka': '🟡',
+  'marktkauf': '🟠',
+  'kaufland': '🔴',
+  'penny': '🔴',
+  'netto marken-discount': '🟡',
+  'netto schwarz': '⚫',
+  'globus': '🟢',
+  'hol’ab!': '🟢',
+  "hol'ab!": '🟢',
+  'rossmann': '🔴',
+  'müller': '🟠',
+  'dm': '🔵',
+  'combi': '🟢',
+  'famila nordwest': '🔵',
+  'famila': '🔵',
+};
+
+/// The category an offer's retailer is filed under, e.g. "🔴 REWE".
+///
+/// Empty when the offer names no retailer. A merged row that stands for
+/// several shops keeps its first retailer, which is the one the offer key
+/// already refers to.
+String retailerCategory(String retailer) {
+  final name = _clean(retailer);
+  if (name.isEmpty) return '';
+  final icon = _retailerIcons[name.toLowerCase()] ?? '🛒';
+  return '$icon $name';
+}

--- a/app/lib/services/settings.dart
+++ b/app/lib/services/settings.dart
@@ -108,6 +108,19 @@ class Settings {
     }
   }
 
+  bool get hasKitchenOwl =>
+      kitchenOwlUrl.isNotEmpty && kitchenOwlToken.isNotEmpty;
+
+  static const _kitchenOwlOnly = 'kitchenowl_only';
+
+  /// Hide the app's own shopping list and send every offer to KitchenOwl.
+  /// Only meaningful with a direct KitchenOwl connection; without one the
+  /// local list stays, so the button on an offer is never a dead end.
+  bool get kitchenOwlOnly =>
+      hasKitchenOwl && (_prefs.getBool(_kitchenOwlOnly) ?? false);
+  Future<void> setKitchenOwlOnly(bool value) =>
+      _prefs.setBool(_kitchenOwlOnly, value);
+
   String get postalCode => _prefs.getString(_postalCode) ?? '';
   bool get hasPostalCode => _prefs.containsKey(_postalCode);
   Future<void> setPostalCode(String value) =>

--- a/app/lib/widgets/offer_card.dart
+++ b/app/lib/widgets/offer_card.dart
@@ -18,6 +18,7 @@ class OfferCard extends StatelessWidget {
     required this.sending,
     required this.onAddToList,
     required this.onOpenSource,
+    this.onAddToKitchenOwl,
   });
 
   final Offer offer;
@@ -31,11 +32,18 @@ class OfferCard extends StatelessWidget {
   /// the web interface's `single-retailer` rule.
   final bool showRetailer;
 
-  /// The list this offer was already filed in, or null while it has not been.
+  /// The KitchenOwl list this offer was already filed in, or null while it
+  /// has not been.
   final String? filedIn;
   final bool sending;
-  final VoidCallback onAddToList;
+
+  /// Adds the offer to the app's local list. Null hides that button, which
+  /// is what "only KitchenOwl" in the settings means.
+  final VoidCallback? onAddToList;
   final VoidCallback onOpenSource;
+
+  /// Files the offer in KitchenOwl. Null while no KitchenOwl is connected.
+  final VoidCallback? onAddToKitchenOwl;
 
   Color _stateColor(String state, KorbColors colors) =>
       state == 'best' ? colors.good : colors.text;
@@ -184,31 +192,45 @@ class OfferCard extends StatelessWidget {
           Row(
             children: [
               const Spacer(),
-              TextButton.icon(
-                onPressed: sending || filedIn != null ? null : onAddToList,
-                icon: sending
-                    ? const SizedBox(
-                        height: 16,
-                        width: 16,
-                        child: CircularProgressIndicator(strokeWidth: 2),
-                      )
-                    : Icon(
-                        filedIn != null ? Icons.check : Icons.add_shopping_cart,
-                        size: 18,
-                      ),
-                label: Text(
-                  filedIn != null ? 'in $filedIn' : 'Zur Einkaufsliste',
+              if (onAddToList != null)
+                TextButton.icon(
+                  onPressed: sending ? null : onAddToList,
+                  icon: const Icon(Icons.add_shopping_cart, size: 18),
+                  label: const Text('Zur Einkaufsliste'),
+                  style: TextButton.styleFrom(
+                    foregroundColor: colors.accent,
+                    disabledForegroundColor: colors.muted,
+                    visualDensity: VisualDensity.compact,
+                  ),
                 ),
-                style: TextButton.styleFrom(
-                  foregroundColor: filedIn != null
-                      ? colors.good
-                      : colors.accent,
-                  disabledForegroundColor: filedIn != null
-                      ? colors.good
-                      : colors.muted,
-                  visualDensity: VisualDensity.compact,
+              if (onAddToKitchenOwl != null)
+                TextButton.icon(
+                  onPressed: sending || filedIn != null
+                      ? null
+                      : onAddToKitchenOwl,
+                  icon: sending
+                      ? const SizedBox(
+                          height: 16,
+                          width: 16,
+                          child: CircularProgressIndicator(strokeWidth: 2),
+                        )
+                      : Icon(
+                          filedIn != null ? Icons.check : Icons.playlist_add,
+                          size: 18,
+                        ),
+                  label: Text(
+                    filedIn != null ? 'in $filedIn' : 'Auf KitchenOwl',
+                  ),
+                  style: TextButton.styleFrom(
+                    foregroundColor: filedIn != null
+                        ? colors.good
+                        : colors.accent,
+                    disabledForegroundColor: filedIn != null
+                        ? colors.good
+                        : colors.muted,
+                    visualDensity: VisualDensity.compact,
+                  ),
                 ),
-              ),
             ],
           ),
         ],

--- a/app/test/client_test.dart
+++ b/app/test/client_test.dart
@@ -138,53 +138,121 @@ void main() {
   });
 
   group('direct KitchenOwl transfer', () {
-    test('discovers lists and transfers the real offer fields', () async {
-      final requests = <http.BaseRequest>[];
-      final client = KitchenOwlClient(
-        baseUrl: 'https://owl.example',
-        token: 'long-lived',
-        httpClient: MockClient((request) {
-          requests.add(request);
-          if (request.url.path == '/api/household') {
-            return http.Response(
-              jsonEncode([
-                {'id': 7, 'name': 'Zuhause'},
-              ]),
-              200,
-            );
-          }
-          if (request.url.path == '/api/household/7/shoppinglist') {
-            return http.Response(
-              jsonEncode([
-                {'id': 12, 'name': 'Einkauf'},
-              ]),
-              200,
-            );
-          }
-          if (request.url.path == '/api/shoppinglist/12/add-item-by-name') {
-            return http.Response(jsonEncode({'id': 99}), 200);
-          }
-          return http.Response('{}', 404);
-        }),
-      );
-      final targets = await client.targets();
+    KitchenOwlClient owl(
+      List<http.Request> requests, {
+      List<String> items = const [],
+    }) => KitchenOwlClient(
+      baseUrl: 'https://owl.example',
+      token: 'long-lived',
+      httpClient: MockClient((request) {
+        requests.add(request as http.Request);
+        Object? body;
+        switch ((request.method, request.url.path)) {
+          case ('GET', '/api/household'):
+            body = [
+              {'id': 7, 'name': 'Zuhause'},
+            ];
+          case ('GET', '/api/household/7/shoppinglist'):
+            body = [
+              {'id': 12, 'name': 'Einkauf'},
+            ];
+          case ('GET', '/api/household/7/item'):
+            body = [
+              for (final name in items) {'id': 1, 'name': name},
+            ];
+          case ('GET', '/api/household/7/category'):
+            body = [
+              {'id': 3, 'name': 'Obst'},
+            ];
+          case ('POST', '/api/household/7/category'):
+            body = {'id': 5, 'name': 'neu'};
+          case ('POST', '/api/shoppinglist/12/add-item-by-name'):
+            body = {'id': 99};
+          case ('POST', '/api/item/99'):
+            body = {'id': 99};
+          case ('GET', '/api/shoppinglist/12/items'):
+            body = [
+              {'name': 'Butter'},
+              {
+                'item': {'name': 'Milch'},
+              },
+            ];
+          default:
+            return http.Response('{}', 404);
+        }
+        return http.Response(jsonEncode(body), 200);
+      }),
+    );
+
+    Map<String, dynamic> bodyOf(http.Request request) =>
+        jsonDecode(request.body) as Map<String, dynamic>;
+
+    test('discovers lists together with their household', () async {
+      final requests = <http.Request>[];
+      final targets = await owl(requests).targets();
       expect(targets.single.entityId, '12');
       expect(targets.single.label, 'Zuhause · Einkauf');
-      final offer = Offer.fromJson({
-        'product': 'Kerrygold Butter',
-        'retailer': 'REWE',
-        'effective_price_text': '1,59 €',
-        'pack': '250 g',
-        'validity': 'bis 03.09.',
-      });
-      expect(await client.addOffer('12', offer), 'Kerrygold Butter');
-      final post = requests.last as http.Request;
-      expect(post.headers['Authorization'], 'Bearer long-lived');
-      final payload = jsonDecode(post.body) as Map<String, dynamic>;
-      expect(payload['name'], 'Kerrygold Butter');
-      expect(payload['description'], contains('REWE'));
-      expect(payload['description'], contains('1,59 €'));
+      expect(targets.single.householdId, '7');
+      expect(requests.first.headers['Authorization'], 'Bearer long-lived');
     });
+
+    test(
+      'an offer lands on the household article, under the shop category',
+      () async {
+        final requests = <http.Request>[];
+        final client = owl(requests, items: ['Butter', 'Milch']);
+        final offer = Offer.fromJson({
+          'product': 'Kerrygold Butter',
+          'retailer': 'REWE',
+          'effective_price_text': '1,59 €',
+          'pack': '250 g',
+          'validity': 'bis 03.09.',
+        });
+        expect(await client.addOffer('12', offer, householdId: '7'), 'Butter');
+
+        final added = requests.firstWhere(
+          (request) => request.url.path.endsWith('/add-item-by-name'),
+        );
+        expect(bodyOf(added)['name'], 'Butter');
+        // Offer wording, price, validity; the shop is the category and the
+        // pack size stays out.
+        expect(
+          bodyOf(added)['description'],
+          'Kerrygold Butter · 1,59 € · bis 03.09.',
+        );
+
+        final category = requests.firstWhere(
+          (request) =>
+              request.method == 'POST' &&
+              request.url.path == '/api/household/7/category',
+        );
+        expect(bodyOf(category)['name'], '🔴 REWE');
+        final filed = requests.firstWhere(
+          (request) => request.url.path == '/api/item/99',
+        );
+        expect(bodyOf(filed)['category'], {'id': 5});
+      },
+    );
+
+    test('without a household the shortened name is used as is', () async {
+      final requests = <http.Request>[];
+      final offer = Offer.fromJson({
+        'product': 'JA! Weizenbrötchen 6 Stück',
+        'retailer': 'REWE',
+        'regular_price_text': '0,99 €',
+      });
+      expect(await owl(requests).addOffer('12', offer), 'Weizenbrötchen');
+      expect(requests.map((request) => request.url.path), [
+        '/api/shoppinglist/12/add-item-by-name',
+      ]);
+    });
+
+    test(
+      'reads what is currently on the list, nested names included',
+      () async {
+        expect(await owl([]).entries('12'), {'Butter', 'Milch'});
+      },
+    );
 
     test('rejects direct KitchenOwl tokens over HTTP', () async {
       final client = KitchenOwlClient(

--- a/app/test/kitchenowl_articles_test.dart
+++ b/app/test/kitchenowl_articles_test.dart
@@ -1,0 +1,150 @@
+import 'package:flutter_test/flutter_test.dart';
+import 'package:korbklar_app/api/models.dart';
+import 'package:korbklar_app/services/kitchenowl_articles.dart';
+
+Offer _offer({
+  String product = '',
+  String retailer = '',
+  String price = '',
+  String validity = '',
+  String pack = '',
+}) => Offer.fromJson({
+  'product': product,
+  'retailer': retailer,
+  'effective_price_text': price,
+  'validity': validity,
+  'pack': pack,
+  'unit_price': '9,99 €/kg',
+});
+
+void main() {
+  const catalogue = [
+    'Brötchen',
+    'Butter',
+    'Bio Butter',
+    'Milch',
+    'Joghurt',
+    'Ei',
+  ];
+
+  group('matching the household catalogue', () {
+    test('an offer lands on the article the household already keeps', () {
+      // German puts the head noun last, so this is what Brötchen is.
+      expect(
+        matchExistingItem('GUT&GÜNSTIG Weizenbrötchen / Schrippen', catalogue),
+        'Brötchen',
+      );
+      expect(
+        matchExistingItem('Müller Joghurt mit der Ecke', catalogue),
+        'Joghurt',
+      );
+    });
+
+    test('the more specific article wins', () {
+      expect(
+        matchExistingItem('Kerrygold Bio Butter 250g', catalogue),
+        'Bio Butter',
+      );
+    });
+
+    test('a compound is not matched by its first half', () {
+      // Buttermilch is milk, not butter; only the head noun may match.
+      expect(matchExistingItem('Buttermilch 500g', catalogue), 'Milch');
+    });
+
+    test('a compound still beats its head noun', () {
+      expect(
+        matchExistingItem('ja! Buttermilch 1 l', ['Milch', 'Buttermilch']),
+        'Buttermilch',
+      );
+    });
+
+    test('very short articles never match', () {
+      // "Ei" would otherwise swallow half a catalogue.
+      expect(matchExistingItem('Eis am Stiel', catalogue), '');
+    });
+
+    test('an unknown product keeps its own name', () {
+      expect(matchExistingItem('Nektarinen', catalogue), '');
+    });
+
+    test('an earlier headline in the catalogue does not win', () {
+      // Being the longest match for the very offer that created it, it
+      // would beat the household's own article every time.
+      expect(
+        matchExistingItem('GUT&GÜNSTIG Weizenbrötchen / Schrippen', [
+          'Brötchen',
+          'GUT&GÜNSTIG Weizenbrötchen / Schrippen',
+        ]),
+        'Brötchen',
+      );
+    });
+  });
+
+  group('shortening the leaflet wording', () {
+    for (final (product, expected) in const [
+      ('GUT&GÜNSTIG Weizenbrötchen / Schrippen', 'Weizenbrötchen'),
+      ('JA! Weizenbrötchen 6 Stück', 'Weizenbrötchen'),
+      ('REWE Beste Wahl Orangen 1,5 kg', 'Beste Wahl Orangen'),
+      ('Bio Rinderhackfleisch aus der Region 400 g', 'Bio Rinderhackfleisch'),
+      ('Joghurt mild versch. Sorten 500 g', 'Joghurt mild'),
+      ('Coca-Cola 1,25 l', 'Coca-Cola'),
+      // Two plain words are already an article name.
+      ('Kerrygold Butter', 'Kerrygold Butter'),
+      ('Eier', 'Eier'),
+    ]) {
+      test('"$product" becomes "$expected"', () {
+        expect(shortenOfferName(product), expected);
+      });
+    }
+  });
+
+  group('article and note', () {
+    test('a matched article keeps the offer wording in the note', () {
+      final offer = _offer(
+        product: 'JA! Weizenbrötchen 6 Stück',
+        retailer: 'REWE',
+        price: '0,99 €',
+        validity: '01.09.–06.09.2026',
+        pack: '6 Stück',
+      );
+      final article = articleFor(offer, catalogue);
+      expect(article, 'Brötchen');
+      expect(
+        noteFor(offer, article),
+        'JA! Weizenbrötchen 6 Stück · 0,99 € · 01.09.–06.09.2026',
+      );
+    });
+
+    test('the note is offer, price and validity, nothing else', () {
+      // Pack size and unit price are deliberately left out.
+      final offer = _offer(
+        product: 'Kerrygold Butter',
+        retailer: 'REWE',
+        price: '1,59 €',
+        validity: 'bis 03.09.',
+        pack: '250 g',
+      );
+      final article = articleFor(offer, const []);
+      expect(article, 'Kerrygold Butter');
+      expect(noteFor(offer, article), '1,59 € · bis 03.09.');
+    });
+
+    test('a nameless offer is still filed', () {
+      expect(articleFor(_offer(retailer: 'Lidl'), const []), 'Angebot Lidl');
+    });
+  });
+
+  group('retailer categories', () {
+    test('known shops get their colour, others a basket', () {
+      expect(retailerCategory('REWE'), '🔴 REWE');
+      expect(retailerCategory('ALDI Nord'), '🔵 ALDI Nord');
+      expect(retailerCategory('Netto schwarz'), '⚫ Netto schwarz');
+      expect(retailerCategory('Bäcker Meier'), '🛒 Bäcker Meier');
+    });
+
+    test('no retailer, no category', () {
+      expect(retailerCategory('  '), '');
+    });
+  });
+}

--- a/app/test/settings_test.dart
+++ b/app/test/settings_test.dart
@@ -62,4 +62,18 @@ void main() {
     SharedPreferences.setMockInitialValues({'last_search_id': 'search-1'});
     expect((await Settings.load()).lastSearch, isNull);
   });
+
+  test('KitchenOwl alone needs a KitchenOwl', () async {
+    // Widget tests have no Keystore, so the token can only be absent here;
+    // the switch must then read as off however it was stored.
+    SharedPreferences.setMockInitialValues({
+      'kitchenowl_only': true,
+      'kitchenowl_url': 'https://owl.example',
+    });
+    final settings = await Settings.load();
+    expect(settings.hasKitchenOwl, isFalse);
+    expect(settings.kitchenOwlOnly, isFalse);
+    await settings.setKitchenOwlOnly(false);
+    expect((await Settings.load()).kitchenOwlOnly, isFalse);
+  });
 }


### PR DESCRIPTION
## Was sich ändert

Seit 0.1.14 legt der Knopf auf der Angebotskarte nur noch in der lokalen Liste ab. Eine verbundene KitchenOwl zeigt aber weiterhin ihre Listen-Leiste über den Ergebnissen, hinter der nichts mehr passiert. Dieser PR macht die direkte KitchenOwl-Anbindung der App wieder nutzbar und baut sie so aus, dass in KitchenOwl Artikel statt Prospektüberschriften ankommen.

**Zwei Knöpfe auf der Karte.** „Zur Einkaufsliste“ bleibt, wie in 0.1.14 eingeführt. Ist eine KitchenOwl verbunden, kommt „Auf KitchenOwl“ dazu; nach dem Ablegen steht dort „in Brötchen“, und Abhaken in KitchenOwl löscht die Markierung beim nächsten Laden wieder.

**Schalter „Nur KitchenOwl verwenden“** (Einstellungen → Direktes KitchenOwl) blendet die lokale Liste samt Korb-Icon aus, damit die Karte nur einen Knopf hat. Solange KitchenOwl nicht erreichbar ist, bleibt die lokale Liste trotzdem da, damit ein Angebot immer irgendwohin kann. Der Schalter setzt sich zurück, wenn die KitchenOwl-Verbindung entfernt wird.

**Artikel statt Überschrift.** Die App liest die Artikel des Haushalts und legt das Angebot auf dem passenden ab: „JA! Weizenbrötchen 6 Stück“ landet auf dem vorhandenen „Brötchen“ und behält dessen Symbol. Verglichen wird wortweise; das Deutsche stellt das Grundwort ans Ende, also passt „Weizenbrötchen“ zu „Brötchen“, „Buttermilch“ aber zu „Milch“ und nicht zu „Butter“. Der längste Treffer gewinnt („Bio Butter“ vor „Butter“). Passt nichts, wird der Angebotsname auf das Grundwort gekürzt: geschriene Eigenmarken (auch „JA!“), Packungsgrößen und Zusätze wie „aus der Region“ fallen weg. Katalogeinträge mit mehr als drei Wörtern gelten als frühere Überschrift und werden nie herangezogen.

**Notiz** unter dem Artikel: Angebotstext (nur wenn der Artikel anders heißt), Preis, Gültigkeit. Packungsgröße und Grundpreis bewusst nicht; die Notiz wird im Laden gelesen.

**Kategorie je Markt.** Jeder Händler wird zur Kategorie mit Farbpunkt nach Logo, „🔴 REWE“, „🟡 Lidl“, „🔵 ALDI Nord“, „⚫ Netto schwarz“, unbekannte Märkte „🛒“. Fehlende Kategorien legt die App an. KitchenOwl-Kategorien haben kein Bildfeld, das Emoji im Namen ist der einzige Weg zu einem Symbol. So lässt sich die Liste in KitchenOwl nach Laden sortieren.

**Ergebnis-Titel.** Neben bis zu fünf Aktionen rechts lief „PLZ 26188“ auf schmalen Geräten über; der Titel kürzt jetzt mit Ellipse, und der Offline-Chip ist ein Icon.

## Wo die Regeln liegen

`app/lib/services/kitchenowl_articles.dart`, reines Dart ohne Flutter-Abhängigkeit, mit Unit-Tests in `app/test/kitchenowl_articles_test.dart`. `KitchenOwlClient` bekommt `catalogue`, `entries` und legt Kategorien an; `ShoppingListTarget` trägt jetzt die Haushalts-ID, an der Artikel und Kategorien hängen. Der Server-Fallback über `/results/{id}/shopping-list/...` bleibt unangetastet.

KitchenOwl-Endpunkte: `GET /api/household/<id>/item`, `GET|POST /api/household/<id>/category`, `POST /api/shoppinglist/<id>/add-item-by-name`, `POST /api/item/<id>` mit `{"category": {"id": …}}`, `GET /api/shoppinglist/<id>/items`.

## Geprüft

- `flutter analyze` ohne Befund, `flutter test --exclude-tags golden` 74 Tests grün (neu: Abgleich, Kürzen, Notiz, Kategorie, Client-Requests, Einstellungen).
- Goldens nicht neu aufgenommen; der Kartenaufbau hat sich geändert, sie brauchen einen Lauf auf einer Maschine, auf der `flutter test --tags golden --update-goldens` durchläuft.
- Gegen eine laufende KitchenOwl nicht getestet; die Aufrufe entsprechen der Logik, die vorher serverseitig gegen KitchenOwl lief.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01EERRj3aJhVihxPWZEj6QNZ
